### PR TITLE
Add Smithery CLI Installation Instructions & Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mcp-server-kubernetes
-[![smithery badge](https://smithery.ai/badge/mcp-server-kubernetes)](https://smithery.ai/servers/mcp-server-kubernetes)
+[![smithery badge](https://smithery.ai/badge/mcp-server-kubernetes)](https://smithery.ai/server/mcp-server-kubernetes)
 
 MCP Server that can connect to a Kubernetes cluster and manage it.
 
@@ -11,7 +11,7 @@ https://github.com/user-attachments/assets/f25f8f4e-4d04-479b-9ae0-5dac452dd2ed
 
 ### Installing via Smithery
 
-To install Kubernetes Server for Claude Desktop automatically via [Smithery](https://smithery.ai/servers/mcp-server-kubernetes):
+To install Kubernetes Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-server-kubernetes):
 
 ```bash
 npx -y @smithery/cli install mcp-server-kubernetes --client claude

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mcp-server-kubernetes
+[![smithery badge](https://smithery.ai/badge/mcp-server-kubernetes)](https://smithery.ai/servers/mcp-server-kubernetes)
 
 MCP Server that can connect to a Kubernetes cluster and manage it.
-[![smithery badge](https://smithery.ai/badge/mcp-server-kubernetes)](https://smithery.ai/servers/mcp-server-kubernetes)
 
 https://github.com/user-attachments/assets/f25f8f4e-4d04-479b-9ae0-5dac452dd2ed
 
@@ -17,6 +17,7 @@ To install Kubernetes Server for Claude Desktop automatically via [Smithery](htt
 npx -y @smithery/cli install mcp-server-kubernetes --client claude
 ```
 
+### Manual Installation
 ```json
 {
   "mcpServers": {

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # mcp-server-kubernetes
 
 MCP Server that can connect to a Kubernetes cluster and manage it.
+[![smithery badge](https://smithery.ai/badge/mcp-server-kubernetes)](https://smithery.ai/servers/mcp-server-kubernetes)
 
 https://github.com/user-attachments/assets/f25f8f4e-4d04-479b-9ae0-5dac452dd2ed
 
 <a href="https://glama.ai/mcp/servers/w71ieamqrt"><img width="380" height="200" src="https://glama.ai/mcp/servers/w71ieamqrt/badge" /></a>
 
 ## Usage with Claude Desktop
+
+### Installing via Smithery
+
+To install Kubernetes Server for Claude Desktop automatically via [Smithery](https://smithery.ai/servers/mcp-server-kubernetes):
+
+```bash
+npx -y @smithery/cli install mcp-server-kubernetes --client claude
+```
 
 ```json
 {


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Kubernetes Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery.

Let me know if any tweaks have to be made!