### PR TITLE
Update to bun run test

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,7 @@ jobs:
           grep "server:" ~/.kube/config
 
       - name: Run Tests in Minikube
-        run: bun test
+        run: bun run test
 
       - name: Clean up kubectl proxy
         if: always()


### PR DESCRIPTION
`bun test` and `bun run test` don't do the same thing apparently - testing locally bun test wasn't using vitest.config.ts properly while bun run test does.


Summary:

Test Plan:
