### PR TITLE
Add exec_in_pod tool for command execution in Kubernetes pods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import { deletePod, deletePodSchema } from "./tools/delete_pod.js";
 import { describePod, describePodSchema } from "./tools/describe_pod.js";
 import { getLogs, getLogsSchema } from "./tools/get_logs.js";
 import { getEvents, getEventsSchema } from "./tools/get_events.js";
+import { execInPod, execInPodSchema } from "./tools/exec_in_pod.js";
 import { getResourceHandlers } from "./resources/handlers.js";
 import {
   ListResourcesRequestSchema,
@@ -165,6 +166,7 @@ const allTools = [
   DeleteCronJobSchema,
   CreateConfigMapSchema,
   updateServiceSchema,
+  execInPodSchema,
 ];
 
 const k8sManager = new KubernetesManager();
@@ -660,6 +662,18 @@ server.setRequestHandler(
             input as {
               name: string;
               namespace?: string;
+            }
+          );
+        }
+
+        case "exec_in_pod": {
+          return await execInPod(
+            k8sManager,
+            input as {
+              name: string;
+              namespace?: string;
+              command: string | string[];
+              container?: string;
             }
           );
         }

--- a/src/models/response-schemas.ts
+++ b/src/models/response-schemas.ts
@@ -160,3 +160,7 @@ export const SetCurrentContextResponseSchema = z.object({
 export const DescribeNodeResponseSchema = z.object({
   content: z.array(ToolResponseContent),
 });
+
+export const ExecInPodResponseSchema = z.object({
+  content: z.array(ToolResponseContent),
+});

--- a/src/tools/exec_in_pod.ts
+++ b/src/tools/exec_in_pod.ts
@@ -1,0 +1,138 @@
+/**
+ * Tool: exec_in_pod
+ * Execute a command in a Kubernetes pod or container and return the output.
+ * Uses the official Kubernetes client-node Exec API for native execution.
+ * Supports both string and array command formats, and optional container targeting.
+ */
+
+import * as k8s from "@kubernetes/client-node";
+import { KubernetesManager } from "../types.js";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Schema for exec_in_pod tool.
+ * - name: Pod name
+ * - namespace: Namespace (default: "default")
+ * - command: Command to execute (string or array of args)
+ * - container: (Optional) Container name
+ */
+export const execInPodSchema = {
+  name: "exec_in_pod",
+  description: "Execute a command in a Kubernetes pod or container and return the output",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
+        description: "Name of the pod to execute the command in",
+      },
+      namespace: {
+        type: "string",
+        description: "Kubernetes namespace where the pod is located",
+        default: "default",
+      },
+      command: {
+        anyOf: [
+          { type: "string" },
+          { type: "array", items: { type: "string" } }
+        ],
+        description: "Command to execute in the pod (string or array of args)",
+      },
+      container: {
+        type: "string",
+        description: "Container name (required when pod has multiple containers)",
+        optional: true,
+      },
+    },
+    required: ["name", "command"],
+  },
+};
+
+/**
+ * Execute a command in a Kubernetes pod or container using the Kubernetes client-node Exec API.
+ * Returns the stdout output as a text response.
+ * Throws McpError on failure.
+ */
+export async function execInPod(
+  k8sManager: KubernetesManager,
+  input: {
+    name: string;
+    namespace?: string;
+    command: string | string[];
+    container?: string;
+  }
+): Promise<{ content: { type: string; text: string }[] }> {
+  const namespace = input.namespace || "default";
+  // Convert command to array of strings for the Exec API
+  const commandArr = Array.isArray(input.command)
+    ? input.command
+    : input.command.split(" ");
+
+  // Prepare buffers to capture stdout and stderr
+  let stdout = "";
+  let stderr = "";
+
+  // Create writable streams to collect output
+  const stdoutStream = {
+    write: (chunk: string | Buffer) => {
+      stdout += chunk.toString();
+    },
+  };
+  const stderrStream = {
+    write: (chunk: string | Buffer) => {
+      stderr += chunk.toString();
+    },
+  };
+
+  try {
+    // Use the Kubernetes client-node Exec API for native exec
+    const kc = k8sManager.getKubeConfig();
+    const exec = new k8s.Exec(kc);
+
+    await new Promise<void>((resolve, reject) => {
+      exec.exec(
+        namespace,
+        input.name,
+        input.container ?? "",
+        commandArr,
+        stdoutStream as any,
+        stderrStream as any,
+        null, // stdin not needed
+        false, // tty
+        (status: any) => {
+          // Callback after exec finishes
+          if (status && status.status === "Success") {
+            resolve();
+          } else {
+            reject(
+              new McpError(
+                ErrorCode.InternalError,
+                `Exec failed: ${JSON.stringify(status)}`
+              )
+            );
+          }
+        }
+      ).catch(reject);
+    });
+
+    // Return the collected stdout as the result
+    return {
+      content: [
+        {
+          type: "text",
+          text: stdout || stderr || "No output",
+        },
+      ],
+    };
+  } catch (error: any) {
+    // Collect error message and stderr output if available
+    let message = error.message || "Unknown error";
+    if (stderr) {
+      message += "\n" + stderr;
+    }
+    throw new McpError(
+      ErrorCode.InternalError,
+      `Failed to execute command in pod: ${message}`
+    );
+  }
+}

--- a/src/tools/exec_in_pod.ts
+++ b/src/tools/exec_in_pod.ts
@@ -8,6 +8,7 @@
 import * as k8s from "@kubernetes/client-node";
 import { KubernetesManager } from "../types.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { Writable } from "stream";
 
 /**
  * Schema for exec_in_pod tool.
@@ -43,6 +44,11 @@ export const execInPodSchema = {
         description: "Container name (required when pod has multiple containers)",
         optional: true,
       },
+      shell: {
+        type: "string",
+        description: "Shell to use for command execution (e.g. '/bin/sh', '/bin/bash'). If not provided, will use command as-is.",
+        optional: true,
+      },
     },
     required: ["name", "command"],
   },
@@ -60,36 +66,74 @@ export async function execInPod(
     namespace?: string;
     command: string | string[];
     container?: string;
+    shell?: string;
   }
 ): Promise<{ content: { type: string; text: string }[] }> {
   const namespace = input.namespace || "default";
   // Convert command to array of strings for the Exec API
-  const commandArr = Array.isArray(input.command)
-    ? input.command
-    : input.command.split(" ");
+  let commandArr: string[];
+  if (Array.isArray(input.command)) {
+    commandArr = input.command;
+  } else {
+    // Always wrap string commands in a shell for correct parsing
+    const shell = input.shell || "/bin/sh";
+    commandArr = [shell, "-c", input.command];
+    console.log("[exec_in_pod] Using shell:", shell, "Command array:", commandArr);
+  }
 
   // Prepare buffers to capture stdout and stderr
   let stdout = "";
   let stderr = "";
 
-  // Create writable streams to collect output
-  const stdoutStream = {
-    write: (chunk: string | Buffer) => {
+  // Use Node.js Writable streams to collect output
+  const stdoutStream = new Writable({
+    write(chunk, _encoding, callback) {
       stdout += chunk.toString();
-    },
-  };
-  const stderrStream = {
-    write: (chunk: string | Buffer) => {
+      callback();
+    }
+  });
+  const stderrStream = new Writable({
+    write(chunk, _encoding, callback) {
       stderr += chunk.toString();
-    },
-  };
+      callback();
+    }
+  });
+  // Add a dummy stdin stream
+  const stdinStream = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    }
+  });
 
   try {
     // Use the Kubernetes client-node Exec API for native exec
     const kc = k8sManager.getKubeConfig();
     const exec = new k8s.Exec(kc);
 
+    // Add a timeout to avoid hanging forever if exec never returns
     await new Promise<void>((resolve, reject) => {
+      let finished = false;
+      const timeout = setTimeout(() => {
+        if (!finished) {
+          finished = true;
+          reject(
+            new McpError(
+              ErrorCode.InternalError,
+              "Exec operation timed out (possible networking, RBAC, or cluster issue)"
+            )
+          );
+        }
+      }, 20000); // 20 seconds
+
+      console.log("[exec_in_pod] Calling exec.exec with params:", {
+        namespace,
+        pod: input.name,
+        container: input.container ?? "",
+        commandArr,
+        stdoutStreamType: typeof stdoutStream,
+        stderrStreamType: typeof stderrStream,
+      });
+
       exec.exec(
         namespace,
         input.name,
@@ -97,30 +141,44 @@ export async function execInPod(
         commandArr,
         stdoutStream as any,
         stderrStream as any,
-        null, // stdin not needed
-        false, // tty
+        stdinStream as any, // use dummy stdin
+        true, // set tty to true
         (status: any) => {
-          // Callback after exec finishes
-          if (status && status.status === "Success") {
-            resolve();
-          } else {
-            reject(
-              new McpError(
-                ErrorCode.InternalError,
-                `Exec failed: ${JSON.stringify(status)}`
-              )
-            );
-          }
+          console.log("[exec_in_pod] exec.exec callback called. Status:", status);
+          if (finished) return;
+          finished = true;
+          clearTimeout(timeout);
+          // Always resolve; handle errors based on stderr or thrown errors
+          resolve();
         }
-      ).catch(reject);
+      ).catch((err: any) => {
+        console.log("[exec_in_pod] exec.exec threw error:", err);
+        if (!finished) {
+          finished = true;
+          clearTimeout(timeout);
+          reject(
+            new McpError(
+              ErrorCode.InternalError,
+              `Exec threw error: ${err?.message || err}`
+            )
+          );
+        }
+      });
     });
 
     // Return the collected stdout as the result
+    // If there is stderr output or no output at all, treat as error
+    if (stderr || (!stdout && !stderr)) {
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to execute command in pod: ${stderr || "No output"}`
+      );
+    }
     return {
       content: [
         {
           type: "text",
-          text: stdout || stderr || "No output",
+          text: stdout,
         },
       ],
     };

--- a/tests/exec_in_pod.test.ts
+++ b/tests/exec_in_pod.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { CreatePodResponseSchema, DeletePodResponseSchema, ListPodsResponseSchema } from "../src/models/response-schemas.js";
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("exec_in_pod tool", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+  let podName: string;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "bun",
+      args: ["src/index.ts"],
+      stderr: "pipe",
+    });
+    client = new Client({ name: "test-client", version: "1.0.0" }, { capabilities: {} });
+    await client.connect(transport);
+    await sleep(1000);
+    // Create a test pod
+    podName = `exec-in-pod-test-${Math.random().toString(36).substring(2, 8)}`;
+    await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "create_pod",
+          arguments: {
+            name: podName,
+            namespace: "default",
+            template: "busybox",
+            command: ["/bin/sh", "-c", "sleep 60"],
+          },
+        },
+      },
+      CreatePodResponseSchema
+    );
+    // Wait for pod to be running
+    let running = false;
+    const start = Date.now();
+    while (!running && Date.now() - start < 30000) {
+      const res = await client.request(
+        {
+          method: "tools/call",
+          params: {
+            name: "describe_pod",
+            arguments: { name: podName, namespace: "default" },
+          },
+        },
+        ListPodsResponseSchema
+      );
+      const status = JSON.parse(res.content[0].text);
+      if (status.status?.phase === "Running") running = true;
+      else await sleep(1000);
+    }
+    expect(running).toBe(true);
+  });
+
+  test("executes a simple command (array form)", async () => {
+    // Print pod status before exec
+    const podStatus = await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "describe_pod",
+          arguments: { name: podName, namespace: "default" },
+        },
+      },
+      ListPodsResponseSchema
+    );
+    console.log("Pod status before exec (array form):", podStatus.content[0].text);
+
+    const result = await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "exec_in_pod",
+          arguments: {
+            name: podName,
+            namespace: "default",
+            command: ["echo", "hello-world"],
+            container: "main",
+          },
+        },
+      },
+      ListPodsResponseSchema
+    );
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toContain("hello-world");
+  });
+
+  test("executes a command (string form)", async () => {
+    // Print pod status before exec
+    const podStatus = await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "describe_pod",
+          arguments: { name: podName, namespace: "default" },
+        },
+      },
+      ListPodsResponseSchema
+    );
+    console.log("Pod status before exec (string form):", podStatus.content[0].text);
+
+    const result = await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "exec_in_pod",
+          arguments: {
+            name: podName,
+            namespace: "default",
+            command: "echo string-form-test",
+            container: "main",
+          },
+        },
+      },
+      ListPodsResponseSchema
+    );
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toContain("string-form-test");
+  });
+
+  test("returns error for non-existent pod", async () => {
+    let errorCaught = false;
+    try {
+      await client.request(
+        {
+          method: "tools/call",
+          params: {
+            name: "exec_in_pod",
+            arguments: {
+              name: "does-not-exist",
+              namespace: "default",
+              command: "echo should-fail",
+            },
+          },
+        },
+        ListPodsResponseSchema
+      );
+    } catch (e: any) {
+      errorCaught = true;
+      expect(e.message).toMatch(/Failed to execute command in pod/);
+    }
+    expect(errorCaught).toBe(true);
+  });
+
+  test("returns error for failing command", async () => {
+    let errorCaught = false;
+    try {
+      await client.request(
+        {
+          method: "tools/call",
+          params: {
+            name: "exec_in_pod",
+            arguments: {
+              name: podName,
+              namespace: "default",
+              command: ["sh", "-c", "exit 1"],
+              container: "main",
+            },
+          },
+        },
+        ListPodsResponseSchema
+      );
+    } catch (e: any) {
+      errorCaught = true;
+      expect(e.message).toMatch(/Failed to execute command in pod/);
+    }
+    expect(errorCaught).toBe(true);
+  });
+
+  // Cleanup
+  afterAll(async () => {
+    await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "delete_pod",
+          arguments: {
+            name: podName,
+            namespace: "default",
+            ignoreNotFound: true,
+          },
+        },
+      },
+      DeletePodResponseSchema
+    );
+    await transport.close();
+  });
+});


### PR DESCRIPTION
Introduce a new tool to execute commands within Kubernetes pods, enhancing the functionality with a schema for input validation and response handling. The implementation supports both string and array command formats, along with an optional shell specification.