### PR TITLE
fix: remove console.log calls that break stdio transport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -411,7 +411,7 @@ if (process.env.ENABLE_UNSAFE_SSE_TRANSPORT) {
 } else {
   const transport = new StdioServerTransport();
   
-  console.log(
+  console.error(
     `Starting Kubernetes MCP server v${serverConfig.version}, handling commands...`
   );
   

--- a/src/tools/kubectl-generic.ts
+++ b/src/tools/kubectl-generic.ts
@@ -119,7 +119,7 @@ export async function kubectlGeneric(
     // Execute the command (join all args except the first "kubectl" which is used in execSync)
     const command = cmdArgs.slice(1).join(' ');
     try {
-      console.log(`Executing: kubectl ${command}`);
+      console.error(`Executing: kubectl ${command}`);
       const result = execSync(`kubectl ${command}`, { encoding: "utf8" });
       
       return {


### PR DESCRIPTION
Hey! I've been using `mcp-server-kubernetes` for a couple of days with Desktop Claude and I have the following error show up when starting the app:

![Screenshot 2025-05-30 at 07 25 58 PM@2x](https://github.com/user-attachments/assets/043c5e74-ff03-4677-9bf9-7d59abe07b91)

Digging into this repository and the protocol docs, I've figured the issue is because of the start message logged by the server. To fix the issue, I've update the code to log the message to `stderr`.

This follows what is done in official MCPs server (e.g. the [filesystem][1] server logs its start message using `console.error`).

Let me know if you need any changes. Thanks!

[1]: https://github.com/modelcontextprotocol/servers/blob/8fb7bbdab73eddb42aba72e8eab81102efe1d544/src/filesystem/index.ts#L640-L641