### PR TITLE
Adding support for HOST variable for sse transport

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -165,10 +165,10 @@ To enable [SSE transport](https://modelcontextprotocol.io/docs/concepts/transpor
 ENABLE_UNSAFE_SSE_TRANSPORT=1 npx flux159/mcp-server-kubernetes
 ```
 
-This will start an http server with the `/sse` endpoint for server-sent events. Use the `PORT` env var to configure the server port.
+This will start an http server with the `/sse` endpoint for server-sent events. Use the `PORT` env var to configure the server port. Use `HOST` env var to configure listening on interfaces other than localhost.
 
 ```shell
-ENABLE_UNSAFE_SSE_TRANSPORT=1 PORT=3001 npx flux159/mcp-server-kubernetes
+ENABLE_UNSAFE_SSE_TRANSPORT=1 PORT=3001 HOST=0.0.0.0 npx flux159/mcp-server-kubernetes
 ```
 
 This will allow clients to connect via HTTP to the `/sse` endpoint and receive server-sent events. You can test this by using curl (using port 3001 from above):
@@ -195,16 +195,19 @@ If there's no error, you will receive an `event: message` response in the localh
 Note that normally a client would handle this for you. This is just a demonstration of how to use the SSE transport.
 
 #### Documentation on Running SSE Mode with Docker
-Complete Example 
+
+Complete Example
 Assuming your image name is flux159/mcp-server-kubernetes and you need to map ports and set environment parameters, you can run:
 
 ```shell
 docker  run --rm -it -p 3001:3001 -e ENABLE_UNSAFE_SSE_TRANSPORT=1  -e PORT=3001   -v ~/.kube/config:/home/appuser/.kube/config   flux159/mcp-server-kubernetes
 ```
+
 ⚠️ Key safety considerations
 When deploying SSE mode using Docker, due to the insecure SSE transport protocol and sensitive configuration file mounting, strict security constraints must be implemented in the production environment
 
 mcp config
+
 ```shell
 {
   "mcpServers": {

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -29,9 +29,19 @@ export function startSSEServer(server: Server) {
     }
   });
 
-  const port = process.env.PORT || 3000;
-  app.listen(port);
-  console.log(
-    `mcp-kubernetes-server is listening on port ${port}\nUse the following url to connect to the server:\n\http://localhost:${port}/sse`
-  );
+  let port = 3000;
+  try {
+    port = parseInt(process.env.PORT || "3000", 10);
+  } catch (e) {
+    console.error(
+      "Invalid PORT environment variable, using default port 3000."
+    );
+  }
+
+  const host = process.env.HOST || "localhost";
+  app.listen(port, host, () => {
+    console.log(
+      `mcp-kubernetes-server is listening on port ${port}\nUse the following url to connect to the server:\n\http://${host}:${port}/sse`
+    );
+  });
 }


### PR DESCRIPTION

Summary:

See #157

Test Plan:

```
ENABLE_UNSAFE_SSE_TRANSPORT=true PORT=3001 HOST=0.0.0.0 bun run start
$ node dist/index.js
SSE server started
mcp-kubernetes-server is listening on port 3001
Use the following url to connect to the server:
http://0.0.0.0:3001/sse
```
