### PR TITLE
fix: Ignore the CI minikube binary

### DIFF
--- a/.dxtignore
+++ b/.dxtignore
@@ -1,0 +1,1 @@
+minikube-*


### PR DESCRIPTION
Hi! I noticed that the final dxt has a "minikube-linux-amd64" binary it in and I believe that's from the CI build - but doesn't actually need to be in the final extension, right?