### PR TITLE
Removing userconfig from dxt manifest json for now

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,15 +27,6 @@
       "description": "Use kubectl get to retrieve information from cluster"
     }
   ],
-  "user_config": {
-    "kubeconfig_path": {
-      "type": "string",
-      "title": "Kubeconfig env",
-      "description": "KUBECONFIG env var passed to server",
-      "sensitive": false,
-      "required": false
-    }
-  },
   "tools_generated": true,
   "keywords": [
     "kubernetes",


### PR DESCRIPTION
If the user doesn't specify kubeconfig in that configuration setting, the server just errors out if loaded via DXT. This fixes that so that it will use the default ~/.kube/config for now.

Another issue that I found is that setting `KUBECONFIG=~/.kube/config` doesn't actually expand "~" into home dir, so this fails with Claude Desktop.


Summary:

Test Plan:
