### PR TITLE
Helm install via yaml and node management

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ npx mcp-chat --config "%APPDATA%\Claude\claude_desktop_config.json"
   - Run Helm operations
     - Install, upgrade, and uninstall charts
     - Support for custom values, repositories, and versions
+    - Template-based installation (`helm_template_apply`) to bypass authentication issues
 - [x] Troubleshooting Prompt (`k8s-diagnose`)
   - Guides through a systematic Kubernetes troubleshooting flow for pods based on a keyword and optional namespace.
 - [x] Non-destructive mode for read and create/update-only access to clusters
@@ -195,7 +196,7 @@ All read-only and resource creation/update operations remain available:
 
 - Resource Information: `kubectl_get`, `kubectl_describe`, `kubectl_logs`, `explain_resource`, `list_api_resources`
 - Resource Creation/Modification: `kubectl_apply`, `kubectl_create`, `kubectl_scale`, `kubectl_patch`, `kubectl_rollout`
-- Helm Operations: `install_helm_chart`, `upgrade_helm_chart`
+- Helm Operations: `install_helm_chart`, `upgrade_helm_chart`, `helm_template_apply`
 - Connectivity: `port_forward`, `stop_port_forward`
 - Context Management: `kubectl_context`
 
@@ -207,6 +208,53 @@ The following destructive operations are disabled:
 - `uninstall_helm_chart`: Uninstalling Helm charts
 - `cleanup`: Cleanup of managed resources
 - `kubectl_generic`: General kubectl command access (may include destructive operations)
+
+### Helm Template Apply Tool
+
+The `helm_template_apply` tool provides an alternative way to install Helm charts that bypasses authentication issues commonly encountered with certain Kubernetes configurations. This tool is particularly useful when you encounter errors like:
+
+```
+WARNING: Kubernetes configuration file is group-readable. This is insecure.
+Error: INSTALLATION FAILED: Kubernetes cluster unreachable: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
+```
+
+Instead of using `helm install` directly, this tool:
+
+1. Uses `helm template` to generate YAML manifests from the Helm chart
+2. Applies the generated YAML using `kubectl apply`
+3. Handles namespace creation and cleanup automatically
+
+#### Usage Example
+
+```json
+{
+  "name": "helm_template_apply",
+  "arguments": {
+    "name": "events-exporter",
+    "chart": ".",
+    "namespace": "kube-event-exporter",
+    "valuesFile": "values.yaml",
+    "createNamespace": true
+  }
+}
+```
+
+This is equivalent to running:
+```bash
+helm template events-exporter . -f values.yaml > events-exporter.yaml
+kubectl create namespace kube-event-exporter
+kubectl apply -f events-exporter.yaml -n kube-event-exporter
+```
+
+#### Parameters
+
+- `name`: Release name for the Helm chart
+- `chart`: Chart name or path to chart directory
+- `repo`: Chart repository URL (optional if using local chart path)
+- `namespace`: Kubernetes namespace to deploy to
+- `values`: Chart values as an object (optional)
+- `valuesFile`: Path to values.yaml file (optional, alternative to values object)
+- `createNamespace`: Whether to create the namespace if it doesn't exist (default: true)
 
 For additional advanced features, see the [ADVANCED_README.md](ADVANCED_README.md).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,10 @@ import {
   cleanupPodsSchema,
 } from "./tools/cleanup-pods.js";
 import {
+  nodeManagement,
+  nodeManagementSchema,
+} from "./tools/node-management.js";
+import {
   explainResource,
   explainResourceSchema,
   listApiResources,
@@ -97,6 +101,7 @@ const destructiveTools = [
   cleanupSchema, // Cleanup is also destructive as it deletes resources
   kubectlGenericSchema, // Generic kubectl command can perform destructive operations
   cleanupPodsSchema, // Cleanup pods can delete pods
+  nodeManagementSchema, // Node management can drain nodes (destructive)
 ];
 
 // Get all available tools
@@ -128,6 +133,7 @@ const allTools = [
   helmTemplateApplySchema,
   helmTemplateUninstallSchema,
   cleanupPodsSchema,
+  nodeManagementSchema,
 
   // Port forwarding
   PortForwardSchema,
@@ -468,6 +474,22 @@ server.setRequestHandler(
               forceDelete?: boolean;
               allNamespaces?: boolean;
               confirmDelete?: boolean;
+            }
+          );
+        }
+
+        case "node_management": {
+          return await nodeManagement(
+            input as {
+              operation: "cordon" | "drain" | "uncordon" | "list";
+              nodeName?: string;
+              force?: boolean;
+              gracePeriod?: number;
+              deleteLocalData?: boolean;
+              ignoreDaemonsets?: boolean;
+              timeout?: string;
+              dryRun?: boolean;
+              confirmDrain?: boolean;
             }
           );
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,14 @@ import {
   uninstallHelmChartSchema,
 } from "./tools/helm-operations.js";
 import {
+  helmTemplateApply,
+  helmTemplateApplySchema,
+} from "./tools/helm-template-apply.js";
+import {
+  helmTemplateUninstall,
+  helmTemplateUninstallSchema,
+} from "./tools/helm-template-uninstall.js";
+import {
   explainResource,
   explainResourceSchema,
   listApiResources,
@@ -112,6 +120,8 @@ const allTools = [
   installHelmChartSchema,
   upgradeHelmChartSchema,
   uninstallHelmChartSchema,
+  helmTemplateApplySchema,
+  helmTemplateUninstallSchema,
 
   // Port forwarding
   PortForwardSchema,
@@ -414,6 +424,32 @@ server.setRequestHandler(
               repo: string;
               namespace: string;
               values?: Record<string, any>;
+            }
+          );
+        }
+
+        case "helm_template_apply": {
+          return await helmTemplateApply(
+            input as {
+              name: string;
+              chart: string;
+              repo?: string;
+              namespace: string;
+              values?: Record<string, any>;
+              valuesFile?: string;
+              createNamespace?: boolean;
+            }
+          );
+        }
+
+        case "helm_template_uninstall": {
+          return await helmTemplateUninstall(
+            input as {
+              name: string;
+              chart: string;
+              namespace: string;
+              values?: Record<string, any>;
+              valuesFile?: string;
             }
           );
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,10 @@ import {
   helmTemplateUninstallSchema,
 } from "./tools/helm-template-uninstall.js";
 import {
+  cleanupPods,
+  cleanupPodsSchema,
+} from "./tools/cleanup-pods.js";
+import {
   explainResource,
   explainResourceSchema,
   listApiResources,
@@ -92,6 +96,7 @@ const destructiveTools = [
   uninstallHelmChartSchema,
   cleanupSchema, // Cleanup is also destructive as it deletes resources
   kubectlGenericSchema, // Generic kubectl command can perform destructive operations
+  cleanupPodsSchema, // Cleanup pods can delete pods
 ];
 
 // Get all available tools
@@ -122,6 +127,7 @@ const allTools = [
   uninstallHelmChartSchema,
   helmTemplateApplySchema,
   helmTemplateUninstallSchema,
+  cleanupPodsSchema,
 
   // Port forwarding
   PortForwardSchema,
@@ -450,6 +456,18 @@ server.setRequestHandler(
               namespace: string;
               values?: Record<string, any>;
               valuesFile?: string;
+            }
+          );
+        }
+
+        case "cleanup_pods": {
+          return await cleanupPods(
+            input as {
+              namespace: string;
+              dryRun?: boolean;
+              forceDelete?: boolean;
+              allNamespaces?: boolean;
+              confirmDelete?: boolean;
             }
           );
         }

--- a/src/tools/cleanup-pods.ts
+++ b/src/tools/cleanup-pods.ts
@@ -1,0 +1,184 @@
+import { execFileSync } from "child_process";
+import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+
+export const cleanupPodsSchema = {
+  name: "cleanup_pods",
+  description: "List and optionally force delete pods in problematic states (Evicted, ContainerStatusUnknown, Completed, Error, ImagePullBackOff, CrashLoopBackOff). First lists pods, then requires explicit confirmation to delete.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      namespace: {
+        type: "string",
+        description: "Kubernetes namespace to clean up",
+      },
+      dryRun: {
+        type: "boolean",
+        description: "Show list of problematic pods without deleting (default: true)",
+        default: true,
+      },
+      forceDelete: {
+        type: "boolean",
+        description: "Force delete the problematic pods (default: false). Set to true ONLY after reviewing the list from dryRun=true",
+        default: false,
+      },
+      allNamespaces: {
+        type: "boolean",
+        description: "Clean up pods in all namespaces (default: false)",
+        default: false,
+      },
+      confirmDelete: {
+        type: "boolean",
+        description: "Explicit confirmation to delete pods. Must be set to true along with forceDelete=true to actually delete pods",
+        default: false,
+      },
+    },
+    required: ["namespace"],
+  },
+};
+
+interface CleanupPodsParams {
+  namespace: string;
+  dryRun?: boolean;
+  forceDelete?: boolean;
+  allNamespaces?: boolean;
+  confirmDelete?: boolean;
+}
+
+const executeCommand = (command: string, args: string[]): string => {
+  try {
+    return execFileSync(command, args, {
+      encoding: "utf8",
+      timeout: 30000, // 30 seconds timeout
+      maxBuffer: getSpawnMaxBuffer(),
+      env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
+    });
+  } catch (error: any) {
+    throw new Error(`${command} command failed: ${error.message}`);
+  }
+};
+
+const getProblematicPods = (namespace: string, allNamespaces: boolean = false): { [key: string]: string[] } => {
+  const problematicStates = [
+    "Evicted",
+    "ContainerStatusUnknown", 
+    "Completed",
+    "Error",
+    "ImagePullBackOff",
+    "CrashLoopBackOff"
+  ];
+
+  const results: { [key: string]: string[] } = {};
+  const namespaceFlag = allNamespaces ? ["--all-namespaces"] : ["-n", namespace];
+
+  try {
+    // Get all pods
+    const podsOutput = executeCommand("kubectl", ["get", "pods", ...namespaceFlag, "--no-headers"]);
+    
+    // Check each problematic state
+    for (const state of problematicStates) {
+      const matchingPods: string[] = [];
+      
+      // Use grep to find pods in this state
+      try {
+        const grepCommand = `echo '${podsOutput}' | grep "${state}" | awk '{print $1}'`;
+        const podNames = execFileSync("sh", ["-c", grepCommand], {
+          encoding: "utf8",
+          timeout: 10000,
+          maxBuffer: getSpawnMaxBuffer(),
+          env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
+        });
+        
+        if (podNames.trim()) {
+          matchingPods.push(...podNames.trim().split('\n').filter(name => name.trim()));
+        }
+      } catch (grepError) {
+        // No pods found in this state, which is fine
+      }
+      
+      if (matchingPods.length > 0) {
+        results[state] = matchingPods;
+      }
+    }
+  } catch (error: any) {
+    throw new Error(`Failed to get pods: ${error.message}`);
+  }
+
+  return results;
+};
+
+const deletePods = (podNames: string[], namespace: string, allNamespaces: boolean = false): void => {
+  if (podNames.length === 0) return;
+
+  const namespaceFlag = allNamespaces ? ["--all-namespaces"] : ["-n", namespace];
+  
+  for (const podName of podNames) {
+    try {
+      executeCommand("kubectl", [
+        "delete", 
+        "pod", 
+        podName, 
+        ...namespaceFlag,
+        "--force", 
+        "--grace-period=0"
+      ]);
+    } catch (error: any) {
+      console.error(`Failed to delete pod ${podName}: ${error.message}`);
+    }
+  }
+};
+
+export async function cleanupPods(
+  params: CleanupPodsParams
+): Promise<{ content: { type: string; text: string }[] }> {
+  const { namespace, dryRun = true, forceDelete = false, allNamespaces = false, confirmDelete = false } = params;
+
+  try {
+    // Get problematic pods
+    const problematicPods = getProblematicPods(namespace, allNamespaces);
+    
+    // Count total problematic pods
+    const totalPods = Object.values(problematicPods).reduce((sum, pods) => sum + pods.length, 0);
+    
+    let response: any = {
+      namespace: allNamespaces ? "all namespaces" : namespace,
+      dryRun: dryRun,
+      forceDelete: forceDelete,
+      confirmDelete: confirmDelete,
+      totalProblematicPods: totalPods,
+      podsByState: problematicPods,
+    };
+
+    if (totalPods === 0) {
+      response.message = "No problematic pods found";
+    } else if (dryRun) {
+      response.message = `Found ${totalPods} problematic pods (dry run - no deletion performed)`;
+      response.action = "To delete these pods, run again with: forceDelete=true, dryRun=false, and confirmDelete=true";
+      response.nextStep = "Review the list above. If you want to delete these pods, call the tool again with the deletion parameters.";
+    } else if (forceDelete && confirmDelete) {
+      // Delete the pods
+      for (const [state, podNames] of Object.entries(problematicPods)) {
+        deletePods(podNames, namespace, allNamespaces);
+      }
+      response.message = `Force deleted ${totalPods} problematic pods`;
+      response.action = "Pods have been force deleted with --force --grace-period=0";
+    } else if (forceDelete && !confirmDelete) {
+      response.message = `Found ${totalPods} problematic pods (deletion requested but not confirmed)`;
+      response.action = "To actually delete these pods, set confirmDelete=true along with forceDelete=true";
+      response.warning = "Deletion requires explicit confirmation. Set confirmDelete=true to proceed.";
+    } else {
+      response.message = `Found ${totalPods} problematic pods (no deletion performed)`;
+      response.action = "To delete these pods, set forceDelete=true and confirmDelete=true";
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(response, null, 2),
+        },
+      ],
+    };
+  } catch (error: any) {
+    throw new Error(`Failed to cleanup pods: ${error.message}`);
+  }
+} 

--- a/src/tools/helm-template-apply.ts
+++ b/src/tools/helm-template-apply.ts
@@ -1,0 +1,174 @@
+import { execFileSync } from "child_process";
+import { writeFileSync, unlinkSync, mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import yaml from "yaml";
+import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+
+export const helmTemplateApplySchema = {
+  name: "helm_template_apply",
+  description: "Install a Helm chart using template generation and kubectl apply (bypasses authentication issues)",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
+        description: "Release name",
+      },
+      chart: {
+        type: "string",
+        description: "Chart name or path to chart directory",
+      },
+      repo: {
+        type: "string",
+        description: "Chart repository URL (optional if using local chart path)",
+      },
+      namespace: {
+        type: "string",
+        description: "Kubernetes namespace",
+      },
+      values: {
+        type: "object",
+        description: "Chart values",
+        properties: {},
+        additionalProperties: true,
+      },
+      valuesFile: {
+        type: "string",
+        description: "Path to values.yaml file (optional, alternative to values object)",
+      },
+      createNamespace: {
+        type: "boolean",
+        description: "Whether to create the namespace if it doesn't exist",
+        default: true,
+      },
+    },
+    required: ["name", "chart", "namespace"],
+  },
+};
+
+interface HelmTemplateApplyParams {
+  name: string;
+  chart: string;
+  repo?: string;
+  namespace: string;
+  values?: Record<string, any>;
+  valuesFile?: string;
+  createNamespace?: boolean;
+}
+
+const executeCommand = (command: string, args: string[]): string => {
+  try {
+    return execFileSync(command, args, {
+      encoding: "utf8",
+      timeout: 60000, // 60 seconds timeout
+      maxBuffer: getSpawnMaxBuffer(),
+      env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
+    });
+  } catch (error: any) {
+    throw new Error(`${command} command failed: ${error.message}`);
+  }
+};
+
+const writeValuesFile = (name: string, values: Record<string, any>): string => {
+  const filename = `${name}-values.yaml`;
+  writeFileSync(filename, yaml.stringify(values));
+  return filename;
+};
+
+export async function helmTemplateApply(
+  params: HelmTemplateApplyParams
+): Promise<{ content: { type: string; text: string }[] }> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'helm-template-'));
+  let valuesFilePath: string | undefined;
+  let generatedYamlPath: string | undefined;
+
+  try {
+    // Step 1: Add helm repository if provided
+    if (params.repo) {
+      const repoName = params.chart.split("/")[0];
+      executeCommand("helm", ["repo", "add", repoName, params.repo]);
+      executeCommand("helm", ["repo", "update"]);
+    }
+
+    // Step 2: Create namespace if requested
+    if (params.createNamespace !== false) {
+      try {
+        executeCommand("kubectl", ["create", "namespace", params.namespace]);
+      } catch (error: any) {
+        // Namespace might already exist, which is fine
+        if (!error.message.includes("already exists")) {
+          throw error;
+        }
+      }
+    }
+
+    // Step 3: Prepare values file
+    if (params.valuesFile) {
+      valuesFilePath = params.valuesFile;
+    } else if (params.values) {
+      valuesFilePath = join(tempDir, `${params.name}-values.yaml`);
+      writeFileSync(valuesFilePath, yaml.stringify(params.values));
+    }
+
+    // Step 4: Generate YAML using helm template
+    const helmArgs = [
+      "template",
+      params.name,
+      params.chart,
+      "--namespace",
+      params.namespace,
+    ];
+
+    if (valuesFilePath && valuesFilePath !== params.valuesFile) {
+      helmArgs.push("-f", valuesFilePath);
+    } else if (params.valuesFile) {
+      helmArgs.push("-f", params.valuesFile);
+    }
+
+    const generatedYaml = executeCommand("helm", helmArgs);
+
+    // Step 5: Save generated YAML to temporary file
+    generatedYamlPath = join(tempDir, `${params.name}-generated.yaml`);
+    writeFileSync(generatedYamlPath, generatedYaml);
+
+    // Step 6: Apply the generated YAML using kubectl
+    executeCommand("kubectl", ["apply", "-f", generatedYamlPath, "-n", params.namespace]);
+
+    const response = {
+      status: "installed",
+      message: `Successfully installed ${params.name} using helm template + kubectl apply`,
+      details: {
+        namespace: params.namespace,
+        chart: params.chart,
+        generatedYamlPath: generatedYamlPath,
+        valuesUsed: valuesFilePath || "default values",
+      },
+    };
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(response, null, 2),
+        },
+      ],
+    };
+  } catch (error: any) {
+    throw new Error(`Failed to install Helm chart using template method: ${error.message}`);
+  } finally {
+    // Cleanup temporary files
+    try {
+      if (valuesFilePath && valuesFilePath.startsWith(tempDir)) {
+        unlinkSync(valuesFilePath);
+      }
+      if (generatedYamlPath) {
+        unlinkSync(generatedYamlPath);
+      }
+      // Remove temp directory
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch (cleanupError) {
+      // Ignore cleanup errors
+    }
+  }
+} 

--- a/src/tools/helm-template-uninstall.ts
+++ b/src/tools/helm-template-uninstall.ts
@@ -1,0 +1,135 @@
+import { execFileSync } from "child_process";
+import { writeFileSync, unlinkSync, mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import yaml from "yaml";
+import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+
+export const helmTemplateUninstallSchema = {
+  name: "helm_template_uninstall",
+  description: "Uninstall a Helm chart by deleting resources using YAML generated from helm template (bypasses authentication issues)",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
+        description: "Release name (for reference)",
+      },
+      chart: {
+        type: "string",
+        description: "Chart name or path to chart directory",
+      },
+      namespace: {
+        type: "string",
+        description: "Kubernetes namespace",
+      },
+      values: {
+        type: "object",
+        description: "Chart values",
+        properties: {},
+        additionalProperties: true,
+      },
+      valuesFile: {
+        type: "string",
+        description: "Path to values.yaml file (optional, alternative to values object)",
+      },
+    },
+    required: ["name", "chart", "namespace"],
+  },
+};
+
+interface HelmTemplateUninstallParams {
+  name: string;
+  chart: string;
+  namespace: string;
+  values?: Record<string, any>;
+  valuesFile?: string;
+}
+
+const executeCommand = (command: string, args: string[]): string => {
+  try {
+    return execFileSync(command, args, {
+      encoding: "utf8",
+      timeout: 60000, // 60 seconds timeout
+      maxBuffer: getSpawnMaxBuffer(),
+      env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
+    });
+  } catch (error: any) {
+    throw new Error(`${command} command failed: ${error.message}`);
+  }
+};
+
+export async function helmTemplateUninstall(
+  params: HelmTemplateUninstallParams
+): Promise<{ content: { type: string; text: string }[] }> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'helm-template-uninstall-'));
+  let valuesFilePath: string | undefined;
+  let generatedYamlPath: string | undefined;
+
+  try {
+    // Step 1: Prepare values file
+    if (params.valuesFile) {
+      valuesFilePath = params.valuesFile;
+    } else if (params.values) {
+      valuesFilePath = join(tempDir, `${params.name}-values.yaml`);
+      writeFileSync(valuesFilePath, yaml.stringify(params.values));
+    }
+
+    // Step 2: Generate YAML using helm template
+    const helmArgs = [
+      "template",
+      params.name,
+      params.chart,
+      "--namespace",
+      params.namespace,
+    ];
+    if (valuesFilePath && valuesFilePath !== params.valuesFile) {
+      helmArgs.push("-f", valuesFilePath);
+    } else if (params.valuesFile) {
+      helmArgs.push("-f", params.valuesFile);
+    }
+    const generatedYaml = executeCommand("helm", helmArgs);
+
+    // Step 3: Save generated YAML to temporary file
+    generatedYamlPath = join(tempDir, `${params.name}-generated.yaml`);
+    writeFileSync(generatedYamlPath, generatedYaml);
+
+    // Step 4: Delete the resources using kubectl
+    executeCommand("kubectl", ["delete", "-f", generatedYamlPath, "-n", params.namespace]);
+
+    const response = {
+      status: "uninstalled",
+      message: `Successfully uninstalled ${params.name} using helm template + kubectl delete`,
+      details: {
+        namespace: params.namespace,
+        chart: params.chart,
+        generatedYamlPath: generatedYamlPath,
+        valuesUsed: valuesFilePath || "default values",
+      },
+    };
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(response, null, 2),
+        },
+      ],
+    };
+  } catch (error: any) {
+    throw new Error(`Failed to uninstall Helm chart using template method: ${error.message}`);
+  } finally {
+    // Cleanup temporary files
+    try {
+      if (valuesFilePath && valuesFilePath.startsWith(tempDir)) {
+        unlinkSync(valuesFilePath);
+      }
+      if (generatedYamlPath) {
+        unlinkSync(generatedYamlPath);
+      }
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch (cleanupError) {
+      // Ignore cleanup errors
+    }
+  }
+} 

--- a/src/tools/node-management.ts
+++ b/src/tools/node-management.ts
@@ -1,0 +1,276 @@
+import { execFileSync } from "child_process";
+import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+
+export const nodeManagementSchema = {
+  name: "node_management",
+  description: "Manage Kubernetes nodes with cordon, drain, and uncordon operations",
+  inputSchema: {
+    type: "object",
+    properties: {
+      operation: {
+        type: "string",
+        description: "Node operation to perform",
+        enum: ["cordon", "drain", "uncordon", "list"],
+      },
+      nodeName: {
+        type: "string",
+        description: "Name of the node to operate on (required for cordon, drain, uncordon)",
+      },
+      force: {
+        type: "boolean",
+        description: "Force the operation even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet (for drain operation)",
+        default: false,
+      },
+      gracePeriod: {
+        type: "number",
+        description: "Period of time in seconds given to each pod to terminate gracefully (for drain operation)",
+        default: -1,
+      },
+      deleteLocalData: {
+        type: "boolean",
+        description: "Delete local data even if emptyDir volumes are used (for drain operation)",
+        default: false,
+      },
+      ignoreDaemonsets: {
+        type: "boolean",
+        description: "Ignore DaemonSet-managed pods (for drain operation)",
+        default: true,
+      },
+      timeout: {
+        type: "string",
+        description: "The length of time to wait before giving up (for drain operation, e.g., '5m', '1h')",
+        default: "0",
+      },
+      dryRun: {
+        type: "boolean",
+        description: "Show what would be done without actually doing it (for drain operation)",
+        default: false,
+      },
+      confirmDrain: {
+        type: "boolean",
+        description: "Explicit confirmation to drain the node (required for drain operation)",
+        default: false,
+      },
+    },
+    required: ["operation"],
+  },
+};
+
+interface NodeManagementParams {
+  operation: "cordon" | "drain" | "uncordon" | "list";
+  nodeName?: string;
+  force?: boolean;
+  gracePeriod?: number;
+  deleteLocalData?: boolean;
+  ignoreDaemonsets?: boolean;
+  timeout?: string;
+  dryRun?: boolean;
+  confirmDrain?: boolean;
+}
+
+const executeCommand = (command: string, args: string[]): string => {
+  try {
+    return execFileSync(command, args, {
+      encoding: "utf8",
+      timeout: 300000, // 5 minutes timeout for node operations
+      maxBuffer: getSpawnMaxBuffer(),
+      env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
+    });
+  } catch (error: any) {
+    throw new Error(`${command} command failed: ${error.message}`);
+  }
+};
+
+const getNodeStatus = (nodeName: string): any => {
+  try {
+    const output = executeCommand("kubectl", ["get", "node", nodeName, "-o", "json"]);
+    return JSON.parse(output);
+  } catch (error: any) {
+    throw new Error(`Failed to get node status: ${error.message}`);
+  }
+};
+
+const listNodes = (): any => {
+  try {
+    const output = executeCommand("kubectl", ["get", "nodes", "-o", "json"]);
+    return JSON.parse(output);
+  } catch (error: any) {
+    throw new Error(`Failed to list nodes: ${error.message}`);
+  }
+};
+
+export async function nodeManagement(
+  params: NodeManagementParams
+): Promise<{ content: { type: string; text: string }[] }> {
+  const {
+    operation,
+    nodeName,
+    force = false,
+    gracePeriod = -1,
+    deleteLocalData = false,
+    ignoreDaemonsets = true,
+    timeout = "0",
+    dryRun = false,
+    confirmDrain = false,
+  } = params;
+
+  try {
+    let response: any = {
+      operation: operation,
+      timestamp: new Date().toISOString(),
+    };
+
+    switch (operation) {
+      case "list": {
+        const nodes = listNodes();
+        response.message = `Found ${nodes.items?.length || 0} nodes in the cluster`;
+        response.nodes = nodes.items?.map((node: any) => ({
+          name: node.metadata.name,
+          status: node.status?.conditions?.find((c: any) => c.type === "Ready")?.status || "Unknown",
+          schedulable: !node.spec?.unschedulable,
+          taints: node.spec?.taints || [],
+        })) || [];
+        break;
+      }
+
+      case "cordon": {
+        if (!nodeName) {
+          throw new Error("nodeName is required for cordon operation");
+        }
+
+        // Get node status before cordoning
+        const beforeStatus = getNodeStatus(nodeName);
+        const wasSchedulable = !beforeStatus.spec?.unschedulable;
+
+        if (wasSchedulable) {
+          executeCommand("kubectl", ["cordon", nodeName]);
+          response.message = `Successfully cordoned node ${nodeName}`;
+          response.action = "Node marked as unschedulable";
+        } else {
+          response.message = `Node ${nodeName} is already cordoned`;
+          response.action = "No action taken - node already unschedulable";
+        }
+
+        // Get updated status
+        const afterStatus = getNodeStatus(nodeName);
+        response.nodeStatus = {
+          name: nodeName,
+          schedulable: !afterStatus.spec?.unschedulable,
+          conditions: afterStatus.status?.conditions || [],
+        };
+        break;
+      }
+
+      case "uncordon": {
+        if (!nodeName) {
+          throw new Error("nodeName is required for uncordon operation");
+        }
+
+        // Get node status before uncordoning
+        const beforeStatus = getNodeStatus(nodeName);
+        const wasSchedulable = !beforeStatus.spec?.unschedulable;
+
+        if (!wasSchedulable) {
+          executeCommand("kubectl", ["uncordon", nodeName]);
+          response.message = `Successfully uncordoned node ${nodeName}`;
+          response.action = "Node marked as schedulable";
+        } else {
+          response.message = `Node ${nodeName} is already uncordoned`;
+          response.action = "No action taken - node already schedulable";
+        }
+
+        // Get updated status
+        const afterStatus = getNodeStatus(nodeName);
+        response.nodeStatus = {
+          name: nodeName,
+          schedulable: !afterStatus.spec?.unschedulable,
+          conditions: afterStatus.status?.conditions || [],
+        };
+        break;
+      }
+
+      case "drain": {
+        if (!nodeName) {
+          throw new Error("nodeName is required for drain operation");
+        }
+
+        // Get node status before draining
+        const beforeStatus = getNodeStatus(nodeName);
+        const wasSchedulable = !beforeStatus.spec?.unschedulable;
+
+        // Build drain command arguments
+        const drainArgs = ["drain", nodeName];
+
+        if (force) {
+          drainArgs.push("--force");
+        }
+
+        if (gracePeriod !== -1) {
+          drainArgs.push("--grace-period", gracePeriod.toString());
+        }
+
+        if (deleteLocalData) {
+          drainArgs.push("--delete-local-data");
+        }
+
+        if (ignoreDaemonsets) {
+          drainArgs.push("--ignore-daemonsets");
+        }
+
+        if (timeout !== "0") {
+          drainArgs.push("--timeout", timeout);
+        }
+
+        if (dryRun) {
+          drainArgs.push("--dry-run=client");
+        }
+
+        if (dryRun) {
+          // Dry run - show what would be done
+          const dryRunOutput = executeCommand("kubectl", drainArgs);
+          response.message = `Dry run for draining node ${nodeName}`;
+          response.action = "Shows what would be done without actually doing it";
+          response.dryRunOutput = dryRunOutput;
+          response.nextStep = "To actually drain the node, set dryRun=false and confirmDrain=true";
+        } else if (confirmDrain) {
+          // Actually drain the node
+          const drainOutput = executeCommand("kubectl", drainArgs);
+          response.message = `Successfully drained node ${nodeName}`;
+          response.action = "Node drained and marked as unschedulable";
+          response.drainOutput = drainOutput;
+
+          // Get updated status
+          const afterStatus = getNodeStatus(nodeName);
+          response.nodeStatus = {
+            name: nodeName,
+            schedulable: !afterStatus.spec?.unschedulable,
+            conditions: afterStatus.status?.conditions || [],
+          };
+        } else {
+          // Show what would be done without confirmation
+          const dryRunOutput = executeCommand("kubectl", [...drainArgs, "--dry-run=client"]);
+          response.message = `Drain operation requested for node ${nodeName} (not confirmed)`;
+          response.action = "To actually drain the node, set confirmDrain=true";
+          response.warning = "Drain operation requires explicit confirmation. Set confirmDrain=true to proceed.";
+          response.dryRunOutput = dryRunOutput;
+          response.nextStep = "To proceed with draining, call again with confirmDrain=true";
+        }
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown operation: ${operation}`);
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(response, null, 2),
+        },
+      ],
+    };
+  } catch (error: any) {
+    throw new Error(`Node management operation failed: ${error.message}`);
+  }
+} 


### PR DESCRIPTION
- Helm Chart Installation via YAML:

Adds support for installing Helm charts using YAML manifests, improving flexibility for Kubernetes resource management.

- Node Management Enhancements:

Updates and refines node management capabilities, including improved tools for node operations and better integration with the unified kubectl command set.

-fixed top command usage