### PR TITLE
Add support for cluster context in the MCP tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,7 @@ server.setRequestHandler(
             showCurrent?: boolean;
             detailed?: boolean;
             output?: string;
+            context?: string;
           }
         );
       }
@@ -213,6 +214,7 @@ server.setRequestHandler(
             labelSelector?: string;
             fieldSelector?: string;
             sortBy?: string;
+            context?: string;
           }
         );
       }
@@ -225,6 +227,7 @@ server.setRequestHandler(
             name: string;
             namespace?: string;
             allNamespaces?: boolean;
+            context?: string;
           }
         );
       }
@@ -238,6 +241,7 @@ server.setRequestHandler(
             namespace?: string;
             dryRun?: boolean;
             force?: boolean;
+            context?: string;
           }
         );
       }
@@ -255,6 +259,7 @@ server.setRequestHandler(
             allNamespaces?: boolean;
             force?: boolean;
             gracePeriodSeconds?: number;
+            context?: string;
           }
         );
       }
@@ -268,6 +273,7 @@ server.setRequestHandler(
             namespace?: string;
             dryRun?: boolean;
             validate?: boolean;
+            context?: string;
           }
         );
       }
@@ -287,6 +293,7 @@ server.setRequestHandler(
             previous?: boolean;
             follow?: boolean;
             labelSelector?: string;
+            context?: string;
           }
         );
       }
@@ -302,6 +309,7 @@ server.setRequestHandler(
             patchData?: object;
             patchFile?: string;
             dryRun?: boolean;
+            context?: string;
           }
         );
       }
@@ -324,6 +332,7 @@ server.setRequestHandler(
             toRevision?: number;
             timeout?: string;
             watch?: boolean;
+            context?: string;
           }
         );
       }
@@ -340,6 +349,7 @@ server.setRequestHandler(
             outputFormat?: string;
             flags?: Record<string, any>;
             args?: string[];
+            context?: string;
           }
         );
       }
@@ -352,6 +362,7 @@ server.setRequestHandler(
           labelSelector: (input as { labelSelector?: string }).labelSelector,
           sortBy: (input as { sortBy?: string }).sortBy,
           output: (input as { output?: string }).output,
+          context: (input as { context?: string }).context,
         });
       }
 
@@ -378,6 +389,7 @@ server.setRequestHandler(
         case "explain_resource": {
           return await explainResource(
             input as {
+              context?: string;
               resource: string;
               apiVersion?: string;
               recursive?: boolean;
@@ -394,6 +406,7 @@ server.setRequestHandler(
               repo: string;
               namespace: string;
               values?: Record<string, any>;
+              context?: string;
             }
           );
         }
@@ -403,6 +416,7 @@ server.setRequestHandler(
             input as {
               name: string;
               namespace: string;
+              context?: string;
             }
           );
         }
@@ -415,6 +429,7 @@ server.setRequestHandler(
               repo: string;
               namespace: string;
               values?: Record<string, any>;
+              context?: string;
             }
           );
         }
@@ -426,6 +441,7 @@ server.setRequestHandler(
               namespaced?: boolean;
               verbs?: string[];
               output?: "wide" | "name" | "no-headers";
+              context?: string;
             }
           );
         }
@@ -438,6 +454,7 @@ server.setRequestHandler(
               resourceName: string;
               localPort: number;
               targetPort: number;
+              context?: string;
             }
           );
         }
@@ -459,6 +476,7 @@ server.setRequestHandler(
               namespace?: string;
               replicas: number;
               resourceType?: string;
+              context?: string;
             }
           );
         }
@@ -475,6 +493,7 @@ server.setRequestHandler(
               namespace?: string;
               command: string | string[];
               container?: string;
+              context?: string;
             }
           );
         }

--- a/src/models/common-parameters.ts
+++ b/src/models/common-parameters.ts
@@ -1,0 +1,17 @@
+export const contextParameter = {
+  type: "string" as const,
+  description: "Kubeconfig Context to use for the command (optional - defaults to null)",
+  default: "",
+};
+
+export const namespaceParameter = {
+  type: "string" as const,
+  description: "Kubernetes namespace",
+  default: "default",
+};
+
+export const dryRunParameter = {
+  type: "boolean" as const,
+  description: "If true, only validate the resource, don't actually execute the operation",
+  default: false,
+};

--- a/src/models/kubectl-models.ts
+++ b/src/models/kubectl-models.ts
@@ -14,6 +14,7 @@ export interface ExplainResourceParams {
   apiVersion?: string;
   recursive?: boolean;
   output?: "plaintext" | "plaintext-openapiv2";
+  context?: string;
 }
 
 export interface ListApiResourcesParams {
@@ -21,4 +22,5 @@ export interface ListApiResourcesParams {
   namespaced?: boolean;
   verbs?: string[];
   output?: "wide" | "name" | "no-headers";
+  context?: string;
 }

--- a/src/tools/exec_in_pod.ts
+++ b/src/tools/exec_in_pod.ts
@@ -9,6 +9,7 @@ import * as k8s from "@kubernetes/client-node";
 import { KubernetesManager } from "../types.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { Writable } from "stream";
+import { contextParameter, namespaceParameter } from "../models/common-parameters.js";
 
 /**
  * Schema for exec_in_pod tool.
@@ -27,11 +28,7 @@ export const execInPodSchema = {
         type: "string",
         description: "Name of the pod to execute the command in",
       },
-      namespace: {
-        type: "string",
-        description: "Kubernetes namespace where the pod is located",
-        default: "default",
-      },
+      namespace: namespaceParameter,
       command: {
         anyOf: [
           { type: "string" },
@@ -51,12 +48,7 @@ export const execInPodSchema = {
         type: "number",
         description: "Timeout for command - 60000 milliseconds if not specified",
       },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      context: contextParameter,
     },
     required: ["name", "command"],
   },

--- a/src/tools/exec_in_pod.ts
+++ b/src/tools/exec_in_pod.ts
@@ -51,6 +51,12 @@ export const execInPodSchema = {
         type: "number",
         description: "Timeout for command - 60000 milliseconds if not specified",
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
     },
     required: ["name", "command"],
   },
@@ -70,6 +76,7 @@ export async function execInPod(
     container?: string;
     shell?: string;
     timeout?: number;
+    context?: string;
   }
 ): Promise<{ content: { type: string; text: string }[] }> {
   const namespace = input.namespace || "default";
@@ -109,6 +116,11 @@ export async function execInPod(
   });
 
   try {
+    // Set context if provided
+    if (input.context) {
+      k8sManager.setCurrentContext(input.context);
+    }
+
     // Use the Kubernetes client-node Exec API for native exec
     const kc = k8sManager.getKubeConfig();
     const exec = new k8s.Exec(kc);

--- a/src/tools/helm-operations.ts
+++ b/src/tools/helm-operations.ts
@@ -8,6 +8,7 @@ import {
   HelmUpgradeOperation,
 } from "../models/helm-models.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+import { contextParameter, namespaceParameter } from "../models/common-parameters.js";
 
 export const installHelmChartSchema = {
   name: "install_helm_chart",
@@ -27,16 +28,8 @@ export const installHelmChartSchema = {
         type: "string",
         description: "Chart repository URL",
       },
-      namespace: {
-        type: "string",
-        description: "Kubernetes namespace",
-      },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      namespace: namespaceParameter,
+      context: contextParameter,
       values: {
         type: "object",
         description: "Chart values",
@@ -66,16 +59,8 @@ export const upgradeHelmChartSchema = {
         type: "string",
         description: "Chart repository URL",
       },
-      namespace: {
-        type: "string",
-        description: "Kubernetes namespace",
-      },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      namespace: namespaceParameter,
+      context: contextParameter,
       values: {
         type: "object",
         description: "Chart values",
@@ -97,16 +82,8 @@ export const uninstallHelmChartSchema = {
         type: "string",
         description: "Release name",
       },
-      namespace: {
-        type: "string",
-        description: "Kubernetes namespace",
-      },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      namespace: namespaceParameter,
+      context: contextParameter,
     },
     required: ["name", "namespace"],
   },

--- a/src/tools/helm-operations.ts
+++ b/src/tools/helm-operations.ts
@@ -31,6 +31,12 @@ export const installHelmChartSchema = {
         type: "string",
         description: "Kubernetes namespace",
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
       values: {
         type: "object",
         description: "Chart values",
@@ -64,6 +70,12 @@ export const upgradeHelmChartSchema = {
         type: "string",
         description: "Kubernetes namespace",
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
       values: {
         type: "object",
         description: "Chart values",
@@ -88,6 +100,12 @@ export const uninstallHelmChartSchema = {
       namespace: {
         type: "string",
         description: "Kubernetes namespace",
+      },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
       },
     },
     required: ["name", "namespace"],

--- a/src/tools/kubectl-apply.ts
+++ b/src/tools/kubectl-apply.ts
@@ -37,6 +37,12 @@ export const kubectlApplySchema = {
           "If true, immediately remove resources from API and bypass graceful deletion",
         default: false,
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
     },
     required: [],
   },
@@ -50,6 +56,7 @@ export async function kubectlApply(
     namespace?: string;
     dryRun?: boolean;
     force?: boolean;
+    context?: string;
   }
 ) {
   try {
@@ -63,6 +70,7 @@ export async function kubectlApply(
     const namespace = input.namespace || "default";
     const dryRun = input.dryRun || false;
     const force = input.force || false;
+    const context = input.context || "";
 
     let command = "kubectl";
     let args = ["apply"];
@@ -90,6 +98,11 @@ export async function kubectlApply(
     // Add force flag if requested
     if (force) {
       args.push("--force");
+    }
+
+    // Add context if provided
+    if (context) {
+      args.push("--context", context);
     }
 
     // Execute the command

--- a/src/tools/kubectl-apply.ts
+++ b/src/tools/kubectl-apply.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+import { contextParameter, namespaceParameter, dryRunParameter } from "../models/common-parameters.js";
 
 export const kubectlApplySchema = {
   name: "kubectl_apply",
@@ -21,28 +22,15 @@ export const kubectlApplySchema = {
         description:
           "Path to a YAML file to apply (optional - use either manifest or filename)",
       },
-      namespace: {
-        type: "string",
-        description: "Namespace to apply the resource to (optional)",
-        default: "default",
-      },
-      dryRun: {
-        type: "boolean",
-        description: "If true, only validate the resource, don't apply it",
-        default: false,
-      },
+      namespace: namespaceParameter,
+      dryRun: dryRunParameter,
       force: {
         type: "boolean",
         description:
           "If true, immediately remove resources from API and bypass graceful deletion",
         default: false,
       },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      context: contextParameter,
     },
     required: [],
   },

--- a/src/tools/kubectl-create.ts
+++ b/src/tools/kubectl-create.ts
@@ -157,6 +157,12 @@ export const kubectlCreateSchema = {
         description:
           'Annotations to apply to the resource (e.g. ["key1=value1", "key2=value2"])',
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
     },
     required: [],
   },
@@ -203,6 +209,7 @@ export async function kubectlCreate(
     annotations?: string[];
     schedule?: string;
     suspend?: boolean;
+    context?: string;
   }
 ) {
   try {
@@ -231,6 +238,7 @@ export async function kubectlCreate(
     const dryRun = input.dryRun || false;
     const validate = input.validate ?? true;
     const output = input.output || "yaml";
+    const context = input.context || "";
 
     const command = "kubectl";
     const args = ["create"];
@@ -422,6 +430,11 @@ export async function kubectlCreate(
 
     // Add output format
     args.push("-o", output);
+
+    // Add context if provided
+    if (context) {
+      args.push("--context", context);
+    }
 
     // Execute the command
     try {

--- a/src/tools/kubectl-create.ts
+++ b/src/tools/kubectl-create.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+import { contextParameter, namespaceParameter, dryRunParameter } from "../models/common-parameters.js";
 
 export const kubectlCreateSchema = {
   name: "kubectl_create",
@@ -14,12 +15,7 @@ export const kubectlCreateSchema = {
     type: "object",
     properties: {
       // General options
-      dryRun: {
-        type: "boolean",
-        description:
-          "If true, only validate the resource, don't actually create it",
-        default: false,
-      },
+      dryRun: dryRunParameter,
       output: {
         type: "string",
         enum: [
@@ -66,11 +62,7 @@ export const kubectlCreateSchema = {
         type: "string",
         description: "Name of the resource to create",
       },
-      namespace: {
-        type: "string",
-        description: "Namespace to create the resource in",
-        default: "default",
-      },
+      namespace: namespaceParameter,
 
       // ConfigMap specific parameters
       fromLiteral: {
@@ -157,12 +149,7 @@ export const kubectlCreateSchema = {
         description:
           'Annotations to apply to the resource (e.g. ["key1=value1", "key2=value2"])',
       },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      context: contextParameter,
     },
     required: [],
   },

--- a/src/tools/kubectl-delete.ts
+++ b/src/tools/kubectl-delete.ts
@@ -57,6 +57,12 @@ export const kubectlDeleteSchema = {
         description:
           "Period of time in seconds given to the resource to terminate gracefully",
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
     },
     required: ["resourceType", "name", "namespace"],
   },
@@ -74,6 +80,7 @@ export async function kubectlDelete(
     allNamespaces?: boolean;
     force?: boolean;
     gracePeriodSeconds?: number;
+    context?: string;
   }
 ) {
   try {
@@ -96,6 +103,7 @@ export async function kubectlDelete(
     const namespace = input.namespace || "default";
     const allNamespaces = input.allNamespaces || false;
     const force = input.force || false;
+    const context = input.context || "";
 
     const command = "kubectl";
     const args = ["delete"];
@@ -142,6 +150,11 @@ export async function kubectlDelete(
     // Add grace period if specified
     if (input.gracePeriodSeconds !== undefined) {
       args.push(`--grace-period=${input.gracePeriodSeconds}`);
+    }
+
+    // Add context if provided
+    if (context) {
+      args.push("--context", context);
     }
 
     // Execute the command

--- a/src/tools/kubectl-delete.ts
+++ b/src/tools/kubectl-delete.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+import { contextParameter, namespaceParameter } from "../models/common-parameters.js";
 
 export const kubectlDeleteSchema = {
   name: "kubectl_delete",
@@ -22,12 +23,7 @@ export const kubectlDeleteSchema = {
         type: "string",
         description: "Name of the resource to delete",
       },
-      namespace: {
-        type: "string",
-        description:
-          "Namespace of the resource (optional - defaults to 'default' for namespaced resources)",
-        default: "default",
-      },
+      namespace: namespaceParameter,
       labelSelector: {
         type: "string",
         description:
@@ -57,12 +53,7 @@ export const kubectlDeleteSchema = {
         description:
           "Period of time in seconds given to the resource to terminate gracefully",
       },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      context: contextParameter,
     },
     required: ["resourceType", "name", "namespace"],
   },

--- a/src/tools/kubectl-describe.ts
+++ b/src/tools/kubectl-describe.ts
@@ -25,6 +25,12 @@ export const kubectlDescribeSchema = {
           "Namespace of the resource (optional - defaults to 'default' for namespaced resources)",
         default: "default",
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
       allNamespaces: {
         type: "boolean",
         description: "If true, describe resources across all namespaces",
@@ -42,6 +48,7 @@ export async function kubectlDescribe(
     name: string;
     namespace?: string;
     allNamespaces?: boolean;
+    context?: string;
   }
 ) {
   try {
@@ -49,6 +56,7 @@ export async function kubectlDescribe(
     const name = input.name;
     const namespace = input.namespace || "default";
     const allNamespaces = input.allNamespaces || false;
+    const context = input.context || "";
 
     // Build the kubectl command
     const command = "kubectl";
@@ -59,6 +67,10 @@ export async function kubectlDescribe(
       args.push("--all-namespaces");
     } else if (namespace && !isNonNamespacedResource(resourceType)) {
       args.push("-n", namespace);
+    }
+
+    if (context) {
+      args.push("--context", context);
     }
 
     // Execute the command

--- a/src/tools/kubectl-describe.ts
+++ b/src/tools/kubectl-describe.ts
@@ -2,6 +2,7 @@ import { KubernetesManager } from "../types.js";
 import { execFileSync } from "child_process";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+import { namespaceParameter, contextParameter } from "../models/common-parameters.js";
 
 export const kubectlDescribeSchema = {
   name: "kubectl_describe",
@@ -19,18 +20,8 @@ export const kubectlDescribeSchema = {
         type: "string",
         description: "Name of the resource to describe",
       },
-      namespace: {
-        type: "string",
-        description:
-          "Namespace of the resource (optional - defaults to 'default' for namespaced resources)",
-        default: "default",
-      },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      namespace: namespaceParameter,
+      context: contextParameter,
       allNamespaces: {
         type: "boolean",
         description: "If true, describe resources across all namespaces",

--- a/src/tools/kubectl-generic.ts
+++ b/src/tools/kubectl-generic.ts
@@ -2,6 +2,7 @@ import { KubernetesManager } from "../types.js";
 import { execFileSync } from "child_process";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+import { contextParameter, namespaceParameter } from "../models/common-parameters.js";
 
 export const kubectlGenericSchema = {
   name: "kubectl_generic",
@@ -27,11 +28,7 @@ export const kubectlGenericSchema = {
         type: "string",
         description: "Resource name",
       },
-      namespace: {
-        type: "string",
-        description: "Namespace",
-        default: "default",
-      },
+      namespace: namespaceParameter,
       outputFormat: {
         type: "string",
         description: "Output format (e.g. json, yaml, wide)",
@@ -47,12 +44,7 @@ export const kubectlGenericSchema = {
         items: { type: "string" },
         description: "Additional command arguments",
       },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      context: contextParameter,
     },
     required: ["command"],
   },

--- a/src/tools/kubectl-generic.ts
+++ b/src/tools/kubectl-generic.ts
@@ -47,6 +47,12 @@ export const kubectlGenericSchema = {
         items: { type: "string" },
         description: "Additional command arguments",
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
     },
     required: ["command"],
   },
@@ -63,6 +69,7 @@ export async function kubectlGeneric(
     outputFormat?: string;
     flags?: Record<string, any>;
     args?: string[];
+    context?: string;
   }
 ) {
   try {
@@ -111,6 +118,11 @@ export async function kubectlGeneric(
     // Add any additional arguments
     if (input.args && input.args.length > 0) {
       cmdArgs.push(...input.args);
+    }
+
+    // Add context if provided
+    if (input.context) {
+      cmdArgs.push("--context", input.context);
     }
 
     // Execute the command

--- a/src/tools/kubectl-get.ts
+++ b/src/tools/kubectl-get.ts
@@ -52,6 +52,12 @@ export const kubectlGetSchema = {
         description:
           "Sort events by a field (default: lastTimestamp). Only applicable for events.",
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
     },
     required: ["resourceType", "name", "namespace"],
   },
@@ -68,6 +74,7 @@ export async function kubectlGet(
     labelSelector?: string;
     fieldSelector?: string;
     sortBy?: string;
+    context?: string;
   }
 ) {
   try {
@@ -79,6 +86,7 @@ export async function kubectlGet(
     const labelSelector = input.labelSelector || "";
     const fieldSelector = input.fieldSelector || "";
     const sortBy = input.sortBy;
+    const context = input.context || "";
 
     // Build the kubectl command
     const command = "kubectl";
@@ -102,6 +110,10 @@ export async function kubectlGet(
       args.push("--all-namespaces");
     } else if (namespace && !isNonNamespacedResource(resourceType)) {
       args.push("-n", namespace);
+    }
+
+    if (context) {
+      args.push("--context", context);
     }
 
     // Add label selector if provided

--- a/src/tools/kubectl-get.ts
+++ b/src/tools/kubectl-get.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "child_process";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import * as yaml from "js-yaml";
+import { contextParameter, namespaceParameter } from "../models/common-parameters.js";
 
 export const kubectlGetSchema = {
   name: "kubectl_get",
@@ -21,12 +22,7 @@ export const kubectlGetSchema = {
         description:
           "Name of the resource (optional - if not provided, lists all resources of the specified type)",
       },
-      namespace: {
-        type: "string",
-        description:
-          "Namespace of the resource (optional - defaults to 'default' for namespaced resources)",
-        default: "default",
-      },
+      namespace: namespaceParameter,
       output: {
         type: "string",
         enum: ["json", "yaml", "wide", "name", "custom"],
@@ -52,12 +48,7 @@ export const kubectlGetSchema = {
         description:
           "Sort events by a field (default: lastTimestamp). Only applicable for events.",
       },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      context: contextParameter
     },
     required: ["resourceType", "name", "namespace"],
   },

--- a/src/tools/kubectl-logs.ts
+++ b/src/tools/kubectl-logs.ts
@@ -2,6 +2,7 @@ import { KubernetesManager } from "../types.js";
 import { execFileSync } from "child_process";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+import { contextParameter, namespaceParameter } from "../models/common-parameters.js";
 
 export const kubectlLogsSchema = {
   name: "kubectl_logs",
@@ -19,11 +20,7 @@ export const kubectlLogsSchema = {
         type: "string",
         description: "Name of the resource",
       },
-      namespace: {
-        type: "string",
-        description: "Namespace of the resource",
-        default: "default",
-      },
+      namespace: namespaceParameter,
       container: {
         type: "string",
         description:
@@ -60,12 +57,7 @@ export const kubectlLogsSchema = {
         type: "string",
         description: "Filter resources by label selector",
       },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      context: contextParameter,
     },
     required: ["resourceType", "name", "namespace"],
   },

--- a/src/tools/kubectl-logs.ts
+++ b/src/tools/kubectl-logs.ts
@@ -60,6 +60,12 @@ export const kubectlLogsSchema = {
         type: "string",
         description: "Filter resources by label selector",
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
     },
     required: ["resourceType", "name", "namespace"],
   },
@@ -79,12 +85,14 @@ export async function kubectlLogs(
     previous?: boolean;
     follow?: boolean;
     labelSelector?: string;
+    context?: string;
   }
 ) {
   try {
     const resourceType = input.resourceType.toLowerCase();
     const name = input.name;
     const namespace = input.namespace || "default";
+    const context = input.context || "";
 
     const command = "kubectl";
     // Handle different resource types
@@ -99,6 +107,11 @@ export async function kubectlLogs(
 
       // Add options
       args = addLogOptions(args, input);
+
+      // Add context if provided
+      if (context) {
+        args.push("--context", context);
+      }
 
       // Execute the command
       try {
@@ -287,6 +300,10 @@ function addLogOptions(args: string[], input: any): string[] {
 
   if (input.follow) {
     args.push(`--follow`);
+  }
+
+  if (input.context) {
+    args.push("--context", input.context);
   }
 
   return args;

--- a/src/tools/kubectl-operations.ts
+++ b/src/tools/kubectl-operations.ts
@@ -25,6 +25,12 @@ export const explainResourceSchema = {
         description: "Print the fields of fields recursively",
         default: false,
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
       output: {
         type: "string",
         description: "Output format (plaintext or plaintext-openapiv2)",
@@ -49,6 +55,12 @@ export const listApiResourcesSchema = {
       namespaced: {
         type: "boolean",
         description: "If true, only show namespaced resources",
+      },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
       },
       verbs: {
         type: "array",
@@ -80,7 +92,7 @@ const executeKubectlCommand = (command: string, args: string[]): string => {
 };
 
 export async function explainResource(
-  params: ExplainResourceParams
+  params: ExplainResourceParams,
 ): Promise<{ content: { type: string; text: string }[] }> {
   try {
     const command = "kubectl";
@@ -92,6 +104,10 @@ export async function explainResource(
 
     if (params.recursive) {
       args.push("--recursive");
+    }
+
+    if (params.context) {
+      args.push("--context", params.context);
     }
 
     if (params.output) {
@@ -116,7 +132,7 @@ export async function explainResource(
 }
 
 export async function listApiResources(
-  params: ListApiResourcesParams
+  params: ListApiResourcesParams,
 ): Promise<{ content: { type: string; text: string }[] }> {
   try {
     const command = "kubectl";
@@ -136,6 +152,10 @@ export async function listApiResources(
 
     if (params.output) {
       args.push(`-o`, params.output);
+    }
+
+    if (params.context) {
+      args.push("--context", params.context);
     }
 
     const result = executeKubectlCommand(command, args);

--- a/src/tools/kubectl-operations.ts
+++ b/src/tools/kubectl-operations.ts
@@ -4,6 +4,7 @@ import {
   ListApiResourcesParams,
 } from "../models/kubectl-models.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+import { contextParameter } from "../models/common-parameters.js";
 
 export const explainResourceSchema = {
   name: "explain_resource",
@@ -25,12 +26,7 @@ export const explainResourceSchema = {
         description: "Print the fields of fields recursively",
         default: false,
       },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      context: contextParameter,
       output: {
         type: "string",
         description: "Output format (plaintext or plaintext-openapiv2)",

--- a/src/tools/kubectl-patch.ts
+++ b/src/tools/kubectl-patch.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+import { contextParameter, dryRunParameter, namespaceParameter } from "../models/common-parameters.js";
 
 export const kubectlPatchSchema = {
   name: "kubectl_patch",
@@ -22,11 +23,7 @@ export const kubectlPatchSchema = {
         type: "string",
         description: "Name of the resource to patch",
       },
-      namespace: {
-        type: "string",
-        description: "Namespace of the resource",
-        default: "default",
-      },
+      namespace: namespaceParameter,
       patchType: {
         type: "string",
         description: "Type of patch to apply",
@@ -42,18 +39,8 @@ export const kubectlPatchSchema = {
         description:
           "Path to a file containing the patch data (alternative to patchData)",
       },
-      dryRun: {
-        type: "boolean",
-        description:
-          "If true, only print the object that would be sent, without sending it",
-        default: false,
-      },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      dryRun: dryRunParameter,
+      context: contextParameter,
     },
     required: ["resourceType", "name"],
   },

--- a/src/tools/kubectl-patch.ts
+++ b/src/tools/kubectl-patch.ts
@@ -48,6 +48,12 @@ export const kubectlPatchSchema = {
           "If true, only print the object that would be sent, without sending it",
         default: false,
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
     },
     required: ["resourceType", "name"],
   },
@@ -63,6 +69,7 @@ export async function kubectlPatch(
     patchData?: object;
     patchFile?: string;
     dryRun?: boolean;
+    context?: string;
   }
 ) {
   try {
@@ -76,6 +83,7 @@ export async function kubectlPatch(
     const namespace = input.namespace || "default";
     const patchType = input.patchType || "strategic";
     const dryRun = input.dryRun || false;
+    const context = input.context || "";
     let tempFile: string | null = null;
 
     const command = "kubectl";
@@ -110,6 +118,11 @@ export async function kubectlPatch(
     // Add dry-run flag if requested
     if (dryRun) {
       args.push("--dry-run=client");
+    }
+
+    // Add context if provided
+    if (context) {
+      args.push("--context", context);
     }
 
     // Execute the command

--- a/src/tools/kubectl-rollout.ts
+++ b/src/tools/kubectl-rollout.ts
@@ -49,6 +49,12 @@ export const kubectlRolloutSchema = {
         description: "Watch the rollout status in real-time until completion",
         default: false,
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
     },
     required: ["subCommand", "resourceType", "name", "namespace"],
   },
@@ -65,11 +71,13 @@ export async function kubectlRollout(
     toRevision?: number;
     timeout?: string;
     watch?: boolean;
+    context?: string;
   }
 ) {
   try {
     const namespace = input.namespace || "default";
     const watch = input.watch || false;
+    const context = input.context || "";
 
     const command = "kubectl";
     const args = [
@@ -93,6 +101,11 @@ export async function kubectlRollout(
     // Add timeout if specified
     if (input.timeout) {
       args.push(`--timeout=${input.timeout}`);
+    }
+
+    // Add context if provided
+    if (context) {
+      args.push("--context", context);
     }
 
     // Execute the command

--- a/src/tools/kubectl-rollout.ts
+++ b/src/tools/kubectl-rollout.ts
@@ -2,6 +2,7 @@ import { KubernetesManager } from "../types.js";
 import { execFileSync } from "child_process";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+import { contextParameter, namespaceParameter } from "../models/common-parameters.js";
 
 export const kubectlRolloutSchema = {
   name: "kubectl_rollout",
@@ -26,11 +27,7 @@ export const kubectlRolloutSchema = {
         type: "string",
         description: "Name of the resource",
       },
-      namespace: {
-        type: "string",
-        description: "Namespace of the resource",
-        default: "default",
-      },
+      namespace: namespaceParameter,
       revision: {
         type: "number",
         description: "Revision to rollback to (for undo subcommand)",
@@ -49,12 +46,7 @@ export const kubectlRolloutSchema = {
         description: "Watch the rollout status in real-time until completion",
         default: false,
       },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      context: contextParameter,
     },
     required: ["subCommand", "resourceType", "name", "namespace"],
   },

--- a/src/tools/kubectl-scale.ts
+++ b/src/tools/kubectl-scale.ts
@@ -28,6 +28,12 @@ export const kubectlScaleSchema = {
           "Resource type to scale (deployment, replicaset, statefulset)",
         default: "deployment",
       },
+      context: {
+        type: "string",
+        description:
+          "Kubeconfig Context to use for the command (optional - defaults to null)",
+        default: "",
+      },
     },
     required: ["name", "replicas"],
   },
@@ -40,11 +46,13 @@ export async function kubectlScale(
     namespace?: string;
     replicas: number;
     resourceType?: string;
+    context?: string;
   }
 ) {
   try {
     const namespace = input.namespace || "default";
     const resourceType = input.resourceType || "deployment";
+    const context = input.context || "";
 
     const command = "kubectl";
     const args = [
@@ -54,6 +62,11 @@ export async function kubectlScale(
       `--replicas=${input.replicas}`,
       `--namespace=${namespace}`,
     ];
+
+    // Add context if provided
+    if (context) {
+      args.push("--context", context);
+    }
 
     // Execute the command
     try {

--- a/src/tools/kubectl-scale.ts
+++ b/src/tools/kubectl-scale.ts
@@ -2,6 +2,7 @@ import { KubernetesManager } from "../types.js";
 import { execFileSync } from "child_process";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+import { contextParameter, namespaceParameter } from "../models/common-parameters.js";
 
 export const kubectlScaleSchema = {
   name: "kubectl_scale",
@@ -13,11 +14,7 @@ export const kubectlScaleSchema = {
         type: "string",
         description: "Name of the deployment to scale",
       },
-      namespace: {
-        type: "string",
-        description: "Namespace of the deployment",
-        default: "default",
-      },
+      namespace: namespaceParameter,
       replicas: {
         type: "number",
         description: "Number of replicas to scale to",
@@ -28,12 +25,7 @@ export const kubectlScaleSchema = {
           "Resource type to scale (deployment, replicaset, statefulset)",
         default: "deployment",
       },
-      context: {
-        type: "string",
-        description:
-          "Kubeconfig Context to use for the command (optional - defaults to null)",
-        default: "",
-      },
+      context: contextParameter,
     },
     required: ["name", "replicas"],
   },

--- a/tests/kubectl.test.ts
+++ b/tests/kubectl.test.ts
@@ -402,5 +402,31 @@ describe("kubectl operations", () => {
       expect(events.events).toBeDefined();
       expect(Array.isArray(events.events)).toBe(true);
     });
+
+    test("get events with custom invalid context should fail", async () => {
+      try {
+        await retry(async () => {
+          return await client.request(
+            {
+              method: "tools/call",
+              params: {
+                name: "kubectl_get",
+                arguments: {
+                  resourceType: "events",
+                  namespace: "default",
+                  output: "json",
+                  context: "non-existent-cluster"
+                },
+              },
+            },
+            asResponseSchema(KubectlResponseSchema)
+          );
+        });
+        
+        expect(true).toBe(false); // This should not execute
+      } catch (error: any) {
+        expect(error.message).toContain('error: context "non-existent-cluster" does not exist');
+      }
+    });
   });
 });


### PR DESCRIPTION
Solves https://github.com/Flux159/mcp-server-kubernetes/issues/183

This PR adds supports for the "--context" parameter in kubectl and helm, so multi-cluster can be achieved without setting a current context in the KUBECONFIG.

This is mostly useful in a scenario where multiple users access the same MCP, so a state is not persisted accross different users.