### PR TITLE
MCP Trust Score

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Issues](https://img.shields.io/github/issues/Flux159/mcp-server-kubernetes)](https://github.com/Flux159/mcp-server-kubernetes/issues)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/Flux159/mcp-server-kubernetes/pulls)
 [![Last Commit](https://img.shields.io/github/last-commit/Flux159/mcp-server-kubernetes)](https://github.com/Flux159/mcp-server-kubernetes/commits/main)
+
+[![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/Flux159/mcp-server-kubernetes)](https://archestra.ai/mcp-catalog/flux159__mcp-server-kubernetes)
 [![smithery badge](https://smithery.ai/badge/mcp-server-kubernetes)](https://smithery.ai/protocol/mcp-server-kubernetes)
 
 MCP Server that can connect to a Kubernetes cluster and manage it. Supports loading kubeconfig from multiple sources in priority order.


### PR DESCRIPTION
Hi!

This PR adds the "Trust Score" badge from our new Open Source MCP catalog.

Our catalog evaluates MCP servers based on technical quality—like protocol feature implementation and dependency health—rather than vanity metrics like GitHub stars.

The scoring process is fully transparent and reproducible:
- Evaluation Script: https://github.com/archestra-ai/website/blob/main/app/app/mcp-catalog/scripts/evaluate-catalog.ts
- Your Server's Page: https://archestra.ai/mcp-catalog/flux159__mcp-server-kubernetes

The badge is designed to be respectful to the structure of your readme, example: [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/topoteretes/cognee/cognee-mcp)](https://archestra.ai/mcp-catalog/topoteretes__cognee__cognee-mcp)

Projects like Grafana MCP (https://github.com/grafana/mcp-grafana) are already participating. 

We believe that transparent and truly open source MCP catalog should help the community to identify great MCP servers like yours 😊

We'd appreciate your support by merging this PR!