### PR TITLE
Fix kubectl context parsing for context names with special characters

### DIFF
--- a/src/tools/kubectl-context.ts
+++ b/src/tools/kubectl-context.ts
@@ -79,23 +79,36 @@ export async function kubectlContext(
 
           // Parse the tabular output from kubectl
           const lines = rawResult.trim().split("\n");
-          const headers = lines[0].trim().split(/\s+/);
-          const currentIndex = headers.indexOf("CURRENT");
-          const nameIndex = headers.indexOf("NAME");
-          const clusterIndex = headers.indexOf("CLUSTER");
-          const authInfoIndex = headers.indexOf("AUTHINFO");
-          const namespaceIndex = headers.indexOf("NAMESPACE");
+          const headerLine = lines[0];
+
+          // Find column positions based on header positions
+          const currentPos = headerLine.indexOf("CURRENT");
+          const namePos = headerLine.indexOf("NAME");
+          const clusterPos = headerLine.indexOf("CLUSTER");
+          const authInfoPos = headerLine.indexOf("AUTHINFO");
+          const namespacePos = headerLine.indexOf("NAMESPACE");
 
           const contexts = [];
           for (let i = 1; i < lines.length; i++) {
-            const columns = lines[i].trim().split(/\s+/);
-            const isCurrent = columns[currentIndex]?.trim() === "*";
+            const line = lines[i];
+            if (line.trim() === "") continue; // Skip empty lines
+
+            // Extract fields based on column positions
+            const isCurrent = line.substring(currentPos, namePos).trim() === "*";
+            const name = line.substring(namePos, clusterPos).trim();
+            const cluster = line.substring(clusterPos, authInfoPos).trim();
+            const authInfo = namespacePos > 0
+              ? line.substring(authInfoPos, namespacePos).trim()
+              : line.substring(authInfoPos).trim();
+            const namespace = namespacePos > 0
+              ? line.substring(namespacePos).trim() || "default"
+              : "default";
 
             contexts.push({
-              name: columns[nameIndex]?.trim(),
-              cluster: columns[clusterIndex]?.trim(),
-              user: columns[authInfoIndex]?.trim(),
-              namespace: columns[namespaceIndex]?.trim() || "default",
+              name: name,
+              cluster: cluster,
+              user: authInfo,
+              namespace: namespace,
               isCurrent: isCurrent,
             });
           }


### PR DESCRIPTION
# Fix kubectl context parsing for context names with special characters

## Problem Description

The `kubectl_context` tool was incorrectly parsing context names that contain special characters like colons (`:`) and at symbols (`@`). Specifically, only the currently active context would display its full name correctly, while inactive contexts would show only partial names (cluster names instead of full context names).

### Example of the Issue

**Expected behavior:**
```json
{
  "contexts": [
    {
      "name": "sre:srereadonly@elegang",
      "cluster": "elegang",
      "user": "elegang:sre:srereadonly",
      "namespace": "sre",
      "isCurrent": false
    },
    {
      "name": "sre:srereadonly@wuxi", 
      "cluster": "wuxi",
      "user": "wuxi:sre:srereadonly",
      "namespace": "sre",
      "isCurrent": true
    }
  ]
}
```

**Actual behavior (before fix):**
```json
{
  "contexts": [
    {
      "name": "elegang",  // ❌ Missing prefix, shows cluster name instead
      "cluster": "elegang",
      "user": "elegang:sre:srereadonly", 
      "namespace": "sre",
      "isCurrent": false
    },
    {
      "name": "sre:srereadonly@wuxi",  // ✅ Correct (only active context worked)
      "cluster": "wuxi",
      "user": "wuxi:sre:srereadonly",
      "namespace": "sre", 
      "isCurrent": true
    }
  ]
}
```

## Root Cause Analysis

The issue was in the table parsing logic in `src/tools/kubectl-context.ts`. The original implementation used `split(/\s+/)` to parse the tabular output from `kubectl config get-contexts`, which assumes consistent column structure across all rows.

### The kubectl output format:
```
CURRENT   NAME                         CLUSTER      AUTHINFO                     NAMESPACE
          sre:srereadonly@elegang      elegang      elegang:sre:srereadonly      sre
          sre:srereadonly@ohio         ohio         ohio:sre:srereadonly         sre  
*         sre:srereadonly@wuxi         wuxi         wuxi:sre:srereadonly         sre
```

### Why the split approach failed:

1. **Inactive rows**: The `CURRENT` column contains only spaces, so after `trim().split(/\s+/)`:
   ```javascript
   // For inactive row: "          sre:srereadonly@elegang      elegang      ..."
   columns = ["sre:srereadonly@elegang", "elegang", "elegang:sre:srereadonly", "sre"]
   //          ^index 0                   ^index 1 (taken as NAME) ❌
   ```

2. **Active row**: The `CURRENT` column contains `*`, so after `trim().split(/\s+/)`:
   ```javascript
   // For active row: "*         sre:srereadonly@wuxi         wuxi         ..."  
   columns = ["*", "sre:srereadonly@wuxi", "wuxi", "wuxi:sre:srereadonly", "sre"]
   //          ^index 0  ^index 1 (taken as NAME) ✅
   ```

3. **The core problem**: The header parsing suggested `NAME` should be at index 1, but due to the empty `CURRENT` column in inactive rows, the actual data structure was inconsistent between active and inactive contexts.

## Solution

Replaced the content-dependent `split()` approach with a **position-based parsing method** that uses fixed column positions determined from the header line.

### Key Changes:

1. **Determine column positions from header**:
   ```javascript
   const headerLine = lines[0];
   const currentPos = headerLine.indexOf("CURRENT");
   const namePos = headerLine.indexOf("NAME"); 
   const clusterPos = headerLine.indexOf("CLUSTER");
   const authInfoPos = headerLine.indexOf("AUTHINFO");
   const namespacePos = headerLine.indexOf("NAMESPACE");
   ```

2. **Extract fields using substring with fixed positions**:
   ```javascript
   // Instead of: columns[nameIndex]?.trim()
   const name = line.substring(namePos, clusterPos).trim();
   const cluster = line.substring(clusterPos, authInfoPos).trim();
   const authInfo = namespacePos > 0 
     ? line.substring(authInfoPos, namespacePos).trim()
     : line.substring(authInfoPos).trim();
   ```

3. **Consistent extraction regardless of row content**:
   - Inactive row: `line.substring(10, 39).trim()` → `"sre:srereadonly@elegang"` ✅
   - Active row: `line.substring(10, 39).trim()` → `"sre:srereadonly@wuxi"` ✅

## Technical Details

### Before (problematic code):
```javascript
const lines = rawResult.trim().split("\n");
const headers = lines[0].trim().split(/\s+/);
const nameIndex = headers.indexOf("NAME"); // nameIndex = 1

for (let i = 1; i < lines.length; i++) {
  const columns = lines[i].trim().split(/\s+/); // ❌ Inconsistent structure
  const name = columns[nameIndex]?.trim();      // ❌ Wrong index for inactive rows
}
```

### After (fixed code):
```javascript
const lines = rawResult.trim().split("\n");
const headerLine = lines[0];
const namePos = headerLine.indexOf("NAME");
const clusterPos = headerLine.indexOf("CLUSTER");

for (let i = 1; i < lines.length; i++) {
  const line = lines[i];
  if (line.trim() === "") continue;
  
  const name = line.substring(namePos, clusterPos).trim(); // ✅ Consistent extraction
}
```

## Why This Solution is Superior

1. **Reliability**: Not dependent on content format - works regardless of whether fields contain spaces or special characters
2. **Performance**: `substring()` operations are faster than `split()` and regex matching
3. **Maintainability**: Simple, clear logic that's easy to understand and debug
4. **Robustness**: Handles edge cases like fields containing spaces or special characters
5. **Consistency**: All rows are parsed using the same logic, eliminating the active/inactive context discrepancy

## Testing

### Manual Testing:
```bash
# Set up test environment
export KUBECONFIG_PATH="$HOME/.kube/merged-kubeconfig"

# Build and test
npm run build
node -e "
import { KubernetesManager } from './dist/utils/kubernetes-manager.js';
import { kubectlContext } from './dist/tools/kubectl-context.js';
const k8sManager = new KubernetesManager();
kubectlContext(k8sManager, { operation: 'list', showCurrent: true })
  .then(result => console.log(JSON.stringify(result, null, 2)));
"
```

### Verification:
- ✅ All context names now display complete names with prefixes
- ✅ Active context detection still works correctly  
- ✅ All other fields (cluster, user, namespace) are parsed correctly
- ✅ No regression in existing functionality

## Impact

This fix resolves the parsing inconsistency for users with complex Kubernetes context naming schemes, particularly those using:
- Contexts with organizational prefixes (e.g., `sre:srereadonly@cluster`)
- Multi-tenant environments with structured naming
- Any context names containing special characters

The fix is backward compatible and doesn't affect users with simpler context names.
