### PR TITLE
Adding privacy policy to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,14 +8,13 @@
     "name": "Flux159",
     "url": "https://github.com/Flux159/"
   },
+  "privacy_policies": ["https://www.linuxfoundation.org/legal/privacy-policy"],
   "server": {
     "type": "node",
     "entry_point": "dist/index.js",
     "mcp_config": {
       "command": "node",
-      "args": [
-        "${__dirname}/dist/index.js"
-      ]
+      "args": ["${__dirname}/dist/index.js"]
     }
   },
   "tools": [
@@ -108,12 +107,7 @@
       "description": "Stop a port-forward process"
     }
   ],
-  "keywords": [
-    "kubernetes",
-    "docker",
-    "containers",
-    "containerization"
-  ],
+  "keywords": ["kubernetes", "docker", "containers", "containerization"],
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION

See #212.

Note that kubernetes.io is managed by cncf (cloud native computing foundation) which has the linux foundation's privacy policy linked on their site. Kubernetes.io is the site for the kubernetes open source projects (including the kubernetes/client-node library that we use as a dependency & the kubectl CLI).

mcp-server-kubernetes does not track any data related to users directly.

Summary:

Test Plan:
