### PR TITLE
fix: Streamable HTTP Server Process Exits After HTTP Connection Closes

### DIFF
--- a/src/utils/streamable-http.ts
+++ b/src/utils/streamable-http.ts
@@ -29,7 +29,10 @@ export function startStreamableHTTPServer(server: Server): http.Server {
         });
       res.on("close", () => {
         transport.close();
-        server.close();
+        // Note: server.close() should NOT be called here as server is shared
+        // across all requests. Calling it would close the global MCP Server
+        // instance and cause the Node.js process to exit. Only the transport
+        // instance needs to be closed when the HTTP connection ends.
       });
       await server.connect(transport);
       await transport.handleRequest(req, res, req.body);


### PR DESCRIPTION

### Description

When running the MCP server in streamable HTTP mode using `ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1`, the Node.js process unexpectedly exits after a period of time (ranging from minutes to hours). This makes the server unreliable for long-running deployments.

### Environment

- **MCP Server Version**: 2.9.6
- **Transport Mode**: Streamable HTTP (`ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1`)
- **Deployment**: Background process using `nohup`
- **Node.js Version**: 18+

### Steps to Reproduce

1. Start the server in streamable HTTP mode with nohup:
```bash
nohup env ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1 \
  PORT=38102 \
  HOST=0.0.0.0 \
  KUBECONFIG_PATH=/path/to/kubeconfig \
  npx mcp-server-kubernetes >> k8s.log 2>&1 &
```

2. Make one or more HTTP requests to the server (e.g., from Claude Desktop or other MCP clients)

3. Wait for several hours without making requests, or wait for the client to disconnect

4. Observe that the Node.js process has exited completely

5. Subsequent connection attempts fail because the server is no longer running

### Expected Behavior

The server should continue running indefinitely, handling new requests even after previous HTTP connections have been closed.

### Actual Behavior

The server process exits after HTTP connections close, making it impossible to connect to the server again without manually restarting it.

### Root Cause Analysis

The issue is in `src/utils/streamable-http.ts`, lines 30-33:

```typescript
res.on("close", () => {
  transport.close();
  server.close();  // ❌ This closes the global MCP Server instance
});
```

**Problem flow:**

1. When an HTTP request is made, a new `StreamableHTTPServerTransport` instance is created
2. The transport is connected to the **global shared** `server` instance (passed as a parameter)
3. After the response is sent, the HTTP connection may stay open for some time (HTTP Keep-Alive)
4. When the connection eventually closes (due to client timeout, network issues, or client shutdown), the `res.on("close")` event fires
5. This event handler calls `server.close()`, which closes the **global MCP Server instance**
6. With the MCP Server closed, Node.js detects no active event loop tasks and the process exits

**Why the timing varies:**

The time until process exit depends on when the HTTP connection closes:
- If the client maintains a Keep-Alive connection, it could be hours
- If the client closes immediately, it could be seconds or minutes
- Network timeouts and client behavior make this unpredictable

### Comparison with SSE Mode

The SSE transport implementation in `src/utils/sse.ts` does NOT call `server.close()` at all. It only manages transport instances, never closing the global server. This is the correct pattern.

### Proposed Solution

Remove the `server.close()` call, as the global server instance should remain running for the lifetime of the process:

```typescript
res.on("close", () => {
  transport.close();
  // Note: server.close() should NOT be called here as server is shared
  // across all requests. Only the transport instance needs to be closed.
});
```

The `server` instance should only be closed on process termination signals (SIGINT/SIGTERM), which is already correctly handled in `src/index.ts` lines 562-568.

### Additional Context

This bug only affects streamable HTTP mode. The SSE transport mode works correctly because it doesn't have this issue.

The comment on line 11 mentions "stateless mode" and "complete isolation", but calling `server.close()` violates this design by affecting the shared global server instance.

### Suggested Fix Location

**File:** `src/utils/streamable-http.ts`  
**Lines:** 30-33

**Current code:**
```typescript
res.on("close", () => {
  transport.close();
  server.close();
});
```

**Fixed code:**
```typescript
res.on("close", () => {
  transport.close();
  // Server instance is shared across all requests and should not be closed
});
```

### Impact

- **Severity**: High - Makes streamable HTTP mode unusable for production deployments
- **Workaround**: Use SSE transport mode instead, or implement external process monitoring to restart the server
- **Affected Users**: Anyone using `ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1` in long-running deployments


