### PR TITLE
fix: set kubeconfig file permissions for non-root access (#226)

### DIFF
--- a/helm-chart/templates/configmap.yaml
+++ b/helm-chart/templates/configmap.yaml
@@ -23,7 +23,8 @@ data:
     
     export KUBECONFIG=/kubeconfig/kubeconfig
     touch $KUBECONFIG
-    
+    chmod 666 $KUBECONFIG
+
     # Function to retry commands
     retry_command() {
       local cmd="$1"
@@ -66,7 +67,8 @@ data:
     
     export KUBECONFIG=/kubeconfig/kubeconfig
     touch $KUBECONFIG
-    
+    chmod 666 $KUBECONFIG
+
     # Function to retry commands
     retry_command() {
       local cmd="$1"
@@ -144,7 +146,8 @@ data:
     # Download: {{ $config.name }}
     CURL_CMD="curl -sS{{- range $config.extraArgs }} {{ . | quote }}{{- end }} -o /kubeconfig/{{ $config.name }}.yaml {{ $config.url | quote }}"
     retry_command "$CURL_CMD" "Downloading kubeconfig {{ $config.name }}"
-    
+    chmod 666 /kubeconfig/{{ $config.name }}.yaml
+
     {{- if eq $index 0 }}
     KUBECONFIG_FILES="/kubeconfig/{{ $config.name }}.yaml"
     {{- else }}


### PR DESCRIPTION
fix #226
This pull request makes minor changes to the `helm-chart/templates/configmap.yaml` script to ensure proper file permissions for kubeconfig files. The main update is the addition of `chmod 666` commands to guarantee that the kubeconfig files are readable and writable by all users, which can help avoid permission issues during deployment or runtime.

File permission adjustments:

* Added `chmod 666 $KUBECONFIG` after creating the main kubeconfig file to ensure it is readable and writable by all users. [[1]](diffhunk://#diff-672c5dc0a114cc59b6e5f201087f5c0d920ba6be9a259bda6d3de5d96102214cR26) [[2]](diffhunk://#diff-672c5dc0a114cc59b6e5f201087f5c0d920ba6be9a259bda6d3de5d96102214cR70)
* Added `chmod 666 /kubeconfig/{{ $config.name }}.yaml` after downloading each kubeconfig file to set appropriate permissions.