### PR TITLE
Updating exec_in_pod to only use string arrays.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -522,8 +522,9 @@ server.setRequestHandler(
             input as {
               name: string;
               namespace?: string;
-              command: string | string[];
+              command: string[];
               container?: string;
+              timeout?: number;
               context?: string;
             }
           );


### PR DESCRIPTION



Strings should not be supported for exec_in_pod.

Summary:

Test Plan:
