### PR TITLE
Update helm push in cd.yml to attempt to fix deployment error

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -115,7 +115,10 @@ jobs:
 
           # Package the chart and push it to GitHub Packages (ghcr.io).
           helm package ./helm-chart
-          helm push *.tgz oci://ghcr.io/${{ github.repository_owner }}
+
+          # OCI registries require lowercase names
+          REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          helm push *.tgz oci://ghcr.io/${REPO_OWNER}
 
       - name: Build dxt
         run: |


### PR DESCRIPTION

From claude:

The Problem:
  OCI registries (like ghcr.io) require all lowercase references. Your
  github.repository_owner was "Flux159" but it needs to be "flux159".

  What's Already Set Up Correctly:
  - The docker/login-action at line 27-32 handles authentication to ghcr.io
  - this works for Helm OCI pushes too
  - GITHUB_TOKEN has write access to packages by default for the repo

  No Additional Setup Required:
  You don't need to create any packages or registries beforehand - ghcr.io
  will automatically create the package when you first push to it.

  After this fix, your chart will be published to:
  oci://ghcr.io/flux159/mcp-server-kubernetes


Summary:

Test Plan:

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Flux159/mcp-server-kubernetes/pull/231).
* __->__ #231
* #229