### PR TITLE
fix: Force NOT to skip K8S_SKIP_TLS_VERIFY when K8S_CA_DATA is provided

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -80,6 +80,8 @@ export K8S_SKIP_TLS_VERIFY='false'  # optional, defaults to false
 
 The `K8S_CA_DATA` environment variable accepts a base64-encoded CA certificate (same format as `certificate-authority-data` in kubeconfig). This allows secure TLS verification without requiring a full kubeconfig file.
 
+**Note:** `K8S_CA_DATA` and `K8S_SKIP_TLS_VERIFY=true` are incompatible. When `K8S_CA_DATA` is provided, `K8S_SKIP_TLS_VERIFY` is automatically forced to `false`. Kubernetes throws an error when both TLS verification is skipped and CA data is provided.
+
 #### Custom Kubeconfig Path
 
 Specify a custom path to your kubeconfig file:

--- a/src/utils/kubernetes-manager.ts
+++ b/src/utils/kubernetes-manager.ts
@@ -181,10 +181,14 @@ export class KubernetesManager {
       );
     }
 
+    // When K8S_CA_DATA is provided, force skipTLSVerify to false as they are incompatible
+    const hasCAData = !!(process.env.K8S_CA_DATA && process.env.K8S_CA_DATA.trim());
+    const skipTLSVerify = hasCAData ? false : process.env.K8S_SKIP_TLS_VERIFY === "true";
+
     const cluster = {
       name: "env-cluster",
       server: process.env.K8S_SERVER,
-      skipTLSVerify: process.env.K8S_SKIP_TLS_VERIFY === "true",
+      skipTLSVerify,
       caData: process.env.K8S_CA_DATA || undefined,
     };
 

--- a/tests/kubernetes-manager.test.ts
+++ b/tests/kubernetes-manager.test.ts
@@ -424,6 +424,28 @@ current-context: test-context`;
         );
       });
 
+      test("should force skipTLSVerify to false when K8S_CA_DATA is set even if K8S_SKIP_TLS_VERIFY is true", () => {
+        process.env.K8S_SERVER = "https://test-cluster.example.com";
+        process.env.K8S_TOKEN = "test-token-12345";
+        process.env.K8S_CA_DATA = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t";
+        process.env.K8S_SKIP_TLS_VERIFY = "true";
+
+        kubernetesManager = new KubernetesManager();
+        const kubeConfig = kubernetesManager.getKubeConfig();
+
+        // Verify skipTLSVerify is forced to false when K8S_CA_DATA is provided
+        expect(kubeConfig.loadFromOptions).toHaveBeenCalledWith(
+          expect.objectContaining({
+            clusters: expect.arrayContaining([
+              expect.objectContaining({
+                caData: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
+                skipTLSVerify: false,
+              }),
+            ]),
+          })
+        );
+      });
+
       test("should not include caData when K8S_CA_DATA is not set", () => {
         process.env.K8S_SERVER = "https://test-cluster.example.com";
         process.env.K8S_TOKEN = "test-token-12345";


### PR DESCRIPTION
Kubernetes API throws an error when both TLS verification is skipped and CA data is provided.