### PR TITLE
Add MCP tool annotations to 9 missing tools

### DIFF
--- a/src/tools/exec_in_pod.ts
+++ b/src/tools/exec_in_pod.ts
@@ -24,6 +24,9 @@ import { contextParameter, namespaceParameter } from "../models/common-parameter
 export const execInPodSchema = {
   name: "exec_in_pod",
   description: "Execute a command in a Kubernetes pod or container and return the output. Command must be an array of strings where the first element is the executable and remaining elements are arguments. This executes directly without shell interpretation for security.",
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/src/tools/helm-operations.ts
+++ b/src/tools/helm-operations.ts
@@ -34,6 +34,9 @@ export const installHelmChartSchema = {
   name: "install_helm_chart",
   description:
     "Install a Helm chart with support for both standard and template-based installation",
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {
@@ -87,6 +90,9 @@ export const installHelmChartSchema = {
 export const upgradeHelmChartSchema = {
   name: "upgrade_helm_chart",
   description: "Upgrade an existing Helm chart release",
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/src/tools/kubectl-apply.ts
+++ b/src/tools/kubectl-apply.ts
@@ -10,6 +10,9 @@ import { contextParameter, namespaceParameter, dryRunParameter } from "../models
 export const kubectlApplySchema = {
   name: "kubectl_apply",
   description: "Apply a Kubernetes YAML manifest from a string or file",
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/src/tools/kubectl-patch.ts
+++ b/src/tools/kubectl-patch.ts
@@ -15,6 +15,9 @@ export const kubectlPatchSchema = {
   name: "kubectl_patch",
   description:
     "Update field(s) of a resource using strategic merge patch, JSON merge patch, or JSON patch",
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/src/tools/kubectl-rollout.ts
+++ b/src/tools/kubectl-rollout.ts
@@ -8,6 +8,9 @@ export const kubectlRolloutSchema = {
   name: "kubectl_rollout",
   description:
     "Manage the rollout of a resource (e.g., deployment, daemonset, statefulset)",
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/src/tools/kubectl-scale.ts
+++ b/src/tools/kubectl-scale.ts
@@ -7,6 +7,9 @@ import { contextParameter, namespaceParameter } from "../models/common-parameter
 export const kubectlScaleSchema = {
   name: "kubectl_scale",
   description: "Scale a Kubernetes deployment",
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/src/tools/port_forward.ts
+++ b/src/tools/port_forward.ts
@@ -56,6 +56,9 @@ async function executeKubectlCommandAsync(
 export const PortForwardSchema = {
   name: "port_forward",
   description: "Forward a local port to a port on a Kubernetes resource",
+  annotations: {
+    title: "Port Forward",
+  },
   inputSchema: {
     type: "object",
     properties: {
@@ -118,6 +121,9 @@ export async function startPortForward(
 export const StopPortForwardSchema = {
   name: "stop_port_forward",
   description: "Stop a port-forward process",
+  annotations: {
+    title: "Stop Port Forward",
+  },
   inputSchema: {
     type: "object",
     properties: {


### PR DESCRIPTION
## Summary
- Added `destructiveHint: true` annotations to 7 tools that modify cluster state
- Added `title` annotations to 2 port forwarding tools for better UX

## Changes
Tools updated with `destructiveHint: true`:
- `exec_in_pod` - Executes commands inside pods
- `kubectl_apply` - Applies Kubernetes manifests
- `kubectl_patch` - Patches resources with strategic/merge/json patches
- `kubectl_rollout` - Manages rollouts (pause/restart/resume/undo)
- `kubectl_scale` - Scales deployments/replicasets/statefulsets
- `install_helm_chart` - Installs Helm charts
- `upgrade_helm_chart` - Upgrades Helm releases

Tools updated with `title` annotation:
- `port_forward` - Title: "Port Forward"
- `stop_port_forward` - Title: "Stop Port Forward"

## Why
MCP tool annotations help LLM clients:
- Understand tool behavior before invocation
- Request appropriate user confirmation for destructive operations
- Display better tool descriptions in UIs

This builds on the existing annotations pattern already used by other tools in this project (e.g., `kubectl_delete`, `kubectl_get`, `uninstall_helm_chart`).

## Test plan
- [x] `npm run build` succeeds
- [x] Verified annotations appear in compiled JS output

🤖 Generated with [Claude Code](https://claude.com/claude-code)