### PR TITLE
Add X-MCP-AUTH header authentication for HTTP transports

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -360,6 +360,76 @@ mcp config
 
 SSE transport exposes an http endpoint that can be accessed by anyone with the URL. This can be a security risk if the server is not properly secured. It is recommended to use a secure proxy server to proxy to the SSE endpoint. In addition, anyone with access to the URL will be able to utilize the authentication of your kubeconfig to make requests to your Kubernetes cluster. You should add logging to your proxy in order to monitor user requests to the SSE endpoint.
 
+### HTTP Transport Authentication (X-MCP-AUTH)
+
+For a quick and simple way to secure HTTP transports (both SSE and Streamable HTTP) without setting up a full proxy, you can use the built-in header-based authentication.
+
+When the `MCP_AUTH_TOKEN` environment variable is set, the server requires all MCP requests to include a matching `X-MCP-AUTH` header. Health and readiness endpoints (`/health`, `/ready`) remain unauthenticated for Kubernetes probes.
+
+#### Server Configuration
+
+```shell
+MCP_AUTH_TOKEN=my-secret-token ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1 npx mcp-server-kubernetes
+```
+
+Or with Docker:
+
+```shell
+docker run --rm -it -p 3001:3001 \
+  -e ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1 \
+  -e PORT=3001 \
+  -e MCP_AUTH_TOKEN=my-secret-token \
+  -v ~/.kube/config:/home/appuser/.kube/config \
+  flux159/mcp-server-kubernetes:latest
+```
+
+#### Client Configuration
+
+**Codex CLI (toml):**
+
+```toml
+[mcp_servers.k8s]
+transport = "streamable-http"
+url = "http://kubernetes-mcp.observe.svc.cluster.local:3001/mcp"
+env_http_headers = { "X-MCP-AUTH" = "X_MCP_AUTH" }
+```
+
+**Gemini CLI (json):**
+
+```json
+{
+  "mcpServers": {
+    "kubernetes": {
+      "type": "http",
+      "url": "http://kubernetes-mcp.observe.svc.cluster.local:3001/mcp",
+      "headers": {
+        "X-MCP-AUTH": "${X_MCP_AUTH}"
+      }
+    }
+  }
+}
+```
+
+**Testing with curl:**
+
+```shell
+# Without auth (will fail with 401)
+curl -X POST http://localhost:3001/mcp
+
+# With auth
+curl -X POST -H "X-MCP-AUTH: my-secret-token" -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"capabilities": {}}}' \
+  http://localhost:3001/mcp
+```
+
+#### Security Considerations
+
+This authentication method is intended as a simple way to add a layer of protection for in-cluster deployments where full OAuth would be overkill. For production internet-facing deployments, consider:
+
+- Using a proper reverse proxy with OAuth/OIDC
+- Deploying behind a service mesh with mTLS
+- Using Kubernetes NetworkPolicies to restrict access
+
 ## Advance Docker Usage
 
 ### Connect to AWS EKS Cluster

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,61 @@
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * Authentication middleware for MCP HTTP transports.
+ *
+ * When the MCP_AUTH_TOKEN environment variable is set, this middleware
+ * requires all requests to include a matching X-MCP-AUTH header.
+ *
+ * This provides a simple authentication mechanism for securing MCP endpoints
+ * in cluster environments where full OAuth may be overkill.
+ *
+ * Example usage:
+ *   Server: MCP_AUTH_TOKEN=my-secret-token
+ *   Client: X-MCP-AUTH: my-secret-token
+ */
+export function createAuthMiddleware() {
+  const authToken = process.env.MCP_AUTH_TOKEN;
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // If no auth token is configured, allow all requests
+    if (!authToken) {
+      next();
+      return;
+    }
+
+    const providedToken = req.headers["x-mcp-auth"];
+
+    if (!providedToken) {
+      res.status(401).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32001,
+          message: "Unauthorized: X-MCP-AUTH header is required",
+        },
+        id: null,
+      });
+      return;
+    }
+
+    if (providedToken !== authToken) {
+      res.status(403).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32002,
+          message: "Forbidden: Invalid authentication token",
+        },
+        id: null,
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+/**
+ * Returns whether authentication is enabled (MCP_AUTH_TOKEN is set)
+ */
+export function isAuthEnabled(): boolean {
+  return !!process.env.MCP_AUTH_TOKEN;
+}


### PR DESCRIPTION

Implements a simple header-based authentication mechanism for SSE and
Streamable HTTP transports, as requested in issue #217.

When MCP_AUTH_TOKEN environment variable is set:
- All MCP endpoints require X-MCP-AUTH header with matching token
- Health/ready endpoints remain unauthenticated for k8s probes
- Returns JSON-RPC error responses (401/403) on auth failure

This provides a quick way to secure HTTP transports in cluster deployments
without requiring a full proxy setup.

Closes #217

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
