### PR TITLE
Fix kubectl_get and kubectl_delete schemas for optional parameters

### DIFF
--- a/src/tools/kubectl-delete.ts
+++ b/src/tools/kubectl-delete.ts
@@ -61,7 +61,7 @@ export const kubectlDeleteSchema = {
       },
       context: contextParameter,
     },
-    required: ["resourceType", "name", "namespace"],
+    required: [],
   },
 } as const;
 

--- a/src/tools/kubectl-get.ts
+++ b/src/tools/kubectl-get.ts
@@ -56,7 +56,7 @@ export const kubectlGetSchema = {
       },
       context: contextParameter,
     },
-    required: ["resourceType", "name", "namespace"],
+    required: ["resourceType"],
   },
 } as const;
 


### PR DESCRIPTION

kubectl_get:
- Removed name and namespace from required array
- Both are optional: name defaults to "" (list all), namespace defaults to "default"
- Fixes "params must have required property 'name'" error when listing resources

kubectl_delete:
- Removed all fields from required array
- The implementation already validates: need resourceType/manifest/filename,
  and if resourceType is used, need name or labelSelector
- Allows deletion by labelSelector or manifest without specifying name

Fixes issue where users couldn't run basic commands like "kubectl get pods".

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Flux159/mcp-server-kubernetes/pull/258).
* __->__ #258
* #255