### PR TITLE
Add support for custom volume-based kubeconfig in Helm chart

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -55,6 +55,46 @@ helm install mcp-server-k8s ./helm-chart \
   --set kubeconfig.url.configs[1].url="https://storage.company.com/staging.yaml"
 ```
 
+### Custom Volume-based Kubeconfig
+
+Use this provider when you want to provide your own volume (Secret, ConfigMap, etc.) containing the kubeconfig. All volume configuration is grouped under `kubeconfig.volume`:
+
+```bash
+helm install mcp-server-k8s ./helm-chart \
+  --set kubeconfig.provider=volume \
+  --set kubeconfig.volume.path=/home/node/.kube/config \
+  --set kubeconfig.volume.volumeSpec.name=kubeconfig \
+  --set kubeconfig.volume.volumeSpec.secret.secretName=my-kubeconfig-secret \
+  --set kubeconfig.volume.volumeMountSpec.name=kubeconfig \
+  --set kubeconfig.volume.volumeMountSpec.mountPath=/home/node/.kube \
+  --set kubeconfig.volume.volumeMountSpec.readOnly=true
+```
+
+Or using a values file:
+
+```yaml
+kubeconfig:
+  provider: volume
+  volume:
+    path: /home/node/.kube/config
+    volumeSpec:
+      name: kubeconfig
+      secret:
+        secretName: my-kubeconfig-secret
+    volumeMountSpec:
+      name: kubeconfig
+      mountPath: /home/node/.kube
+      readOnly: true
+```
+
+This provider is useful when:
+- You have a pre-existing Secret or ConfigMap with kubeconfig
+- You need full control over the volume definition
+- You want to avoid init containers for kubeconfig fetching
+- You're using external secret management tools (External Secrets Operator, Sealed Secrets, etc.)
+
+**Note:** Additional volumes can still be added using `.Values.volumes` and `.Values.volumeMounts` for other purposes
+
 ### Web-Accessible (HTTP Transport)
 
 ```bash

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -109,6 +109,17 @@ false
 {{- end }}
 
 {{/*
+Determine if we need kubeconfig volume mounts
+*/}}
+{{- define "mcp-server-kubernetes.needsKubeconfigVolume" -}}
+{{- if or (eq .Values.kubeconfig.provider "volume") (eq .Values.kubeconfig.provider "content") (eq (include "mcp-server-kubernetes.needsInitContainer" .) "true") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
+{{/*
 Generate kubeconfig environment variable based on provider
 */}}
 {{- define "mcp-server-kubernetes.kubeconfigEnv" -}}
@@ -120,6 +131,8 @@ Generate kubeconfig environment variable based on provider
   {{- $files | join ":" -}}
 {{- else if eq .Values.kubeconfig.provider "content" -}}
   /kubeconfig/kubeconfig.yaml
+{{- else if eq .Values.kubeconfig.provider "volume" -}}
+  {{- .Values.kubeconfig.volume.path | default "/kubeconfig/config" -}}
 {{- else if eq .Values.kubeconfig.provider "serviceaccount" -}}
   {{- /* ServiceAccount mode doesn't need KUBECONFIG env var */ -}}
 {{- else -}}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -125,7 +125,7 @@ spec:
             {{- end }}
             
             # Kubeconfig configuration
-            {{- if ne .Values.kubeconfig.provider "serviceaccount" }}
+            {{- if eq (include "mcp-server-kubernetes.needsKubeconfigVolume" .) "true" }}
             {{- $kubeconfigPath := include "mcp-server-kubernetes.kubeconfigEnv" . }}
             {{- if $kubeconfigPath }}
             - name: KUBECONFIG
@@ -145,17 +145,18 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          {{- if ne .Values.kubeconfig.provider "serviceaccount" }}
+          {{- if or (eq (include "mcp-server-kubernetes.needsKubeconfigVolume" .) "true") .Values.volumeMounts }}
           volumeMounts:
+            {{- if eq (include "mcp-server-kubernetes.needsKubeconfigVolume" .) "true" }}
+              {{- if ne .Values.kubeconfig.provider "volume" }}
             - name: kubeconfig-volume
               mountPath: /kubeconfig
-            {{- range .Values.volumeMounts }}
-            - {{- toYaml . | nindent 14 }}
+              {{- else if .Values.kubeconfig.volume.volumeMountSpec }}
+            {{- list .Values.kubeconfig.volume.volumeMountSpec | toYaml | nindent 12 }}
+              {{- end }}
             {{- end }}
-          {{- else }}
-          volumeMounts:
-            {{- range .Values.volumeMounts }}
-            - {{- toYaml . | nindent 12 }}
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
           {{- $startupProbe := include "mcp-server-kubernetes.startupProbe" . }}
@@ -175,6 +176,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if or (ne (include "mcp-server-kubernetes.needsInitContainer" .) "false") (eq .Values.kubeconfig.provider "content") (and (eq .Values.kubeconfig.provider "volume") .Values.kubeconfig.volume.volumeSpec) .Values.volumes }}
       volumes:
         {{- if eq (include "mcp-server-kubernetes.needsInitContainer" .) "true" }}
         - name: kubeconfig-volume
@@ -188,10 +190,13 @@ spec:
           secret:
             secretName: {{ include "mcp-server-kubernetes.fullname" . }}-kubeconfig
             defaultMode: 0600
+        {{- else if and (eq .Values.kubeconfig.provider "volume") .Values.kubeconfig.volume.volumeSpec }}
+        {{- list .Values.kubeconfig.volume.volumeSpec | toYaml | nindent 8 }}
         {{- end }}
-        {{- range .Values.volumes }}
-        - {{- toYaml . | nindent 10 }}
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
       {{- $nodeSelector := include "mcp-server-kubernetes.nodeSelector" . }}
       {{- if $nodeSelector }}
       nodeSelector:

--- a/helm-chart/templates/tests/test-kubeconfig.yaml
+++ b/helm-chart/templates/tests/test-kubeconfig.yaml
@@ -53,7 +53,7 @@ spec:
     securityContext:
       {{- toYaml .Values.security.securityContext | nindent 6 }}
     env:
-      {{- if ne .Values.kubeconfig.provider "serviceaccount" }}
+      {{- if eq (include "mcp-server-kubernetes.needsKubeconfigVolume" .) "true" }}
       {{- $kubeconfigPath := include "mcp-server-kubernetes.kubeconfigEnv" . }}
       {{- if $kubeconfigPath }}
       - name: KUBECONFIG
@@ -109,11 +109,15 @@ spec:
       kubectl config get-contexts 2>/dev/null || echo "No contexts available"
       
       echo "Kubeconfig test completed successfully"
-    {{- if ne .Values.kubeconfig.provider "serviceaccount" }}
+    {{- if eq (include "mcp-server-kubernetes.needsKubeconfigVolume" .) "true" }}
     volumeMounts:
+      {{- if ne .Values.kubeconfig.provider "volume" }}
       - name: kubeconfig-volume
         mountPath: /kubeconfig
         readOnly: true
+      {{- else if .Values.kubeconfig.volume.volumeMountSpec }}
+      {{- list .Values.kubeconfig.volume.volumeMountSpec | toYaml | nindent 6 }}
+      {{- end }}
     {{- end }}
   volumes:
     {{- if eq (include "mcp-server-kubernetes.needsInitContainer" .) "true" }}
@@ -128,5 +132,7 @@ spec:
       secret:
         secretName: {{ include "mcp-server-kubernetes.fullname" . }}-kubeconfig
         defaultMode: 0600
+    {{- else if and (eq .Values.kubeconfig.provider "volume") .Values.kubeconfig.volume.volumeSpec }}
+    {{- list .Values.kubeconfig.volume.volumeSpec | toYaml | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/helm-chart/values.schema.json
+++ b/helm-chart/values.schema.json
@@ -75,7 +75,7 @@
     "kubeconfig": {
       "type": "object",
       "properties": {
-        "provider": {"type": "string", "enum": ["aws", "gcp", "url", "serviceaccount", "custom", "content"]},
+        "provider": {"type": "string", "enum": ["aws", "gcp", "url", "serviceaccount", "custom", "content", "volume"]},
         "aws": {
           "type": "object",
           "properties": {
@@ -146,6 +146,15 @@
           }
         },
         "content": {"type": "string"},
+        "volume": {
+          "type": "object",
+          "properties": {
+            "path": {"type": "string"},
+            "volumeSpec": {"type": "object"},
+            "volumeMountSpec": {"type": "object"}
+          },
+          "required": ["path", "volumeSpec", "volumeMountSpec"]
+        },
         "env": {"type": "object"},
         "initContainer": {
           "type": "object",


### PR DESCRIPTION
## Description

This PR adds a new `kubeconfig.provider = volume` option that allows users to provide their own volumes (Secret, ConfigMap, etc.) for kubeconfig without requiring init containers.

Closes #259 

## Changes

### Core Implementation

- **`templates/_helpers.tpl`**
  - Added `needsKubeconfigVolume` helper to determine when kubeconfig volume mounts are needed
  - Updated `kubeconfigEnv` helper to support `volume` provider with configurable path via `kubeconfig.volume.path`

- **`templates/deployment.yaml`**
  - Updated KUBECONFIG env var logic to use `needsKubeconfigVolume` helper
  - Fixed volumeMounts rendering to properly handle user-provided volumes using `with` instead of `range`
  - Fixed volumes rendering to properly handle user-provided volumes
  - Made volumes section conditional to avoid empty volumes block

- **`values.schema.json`**
  - Added `"volume"` to kubeconfig provider enum: `["aws", "gcp", "url", "serviceaccount", "custom", "content", "volume"]`
  - Added `volume` object schema with required `path` property

### Testing

- **`templates/tests/test-kubeconfig.yaml`**
  - Updated test pod to support `volume` provider
  - Updated volumeMounts and volumes logic to use user-provided values for volume provider
  - Updated env var logic to use `needsKubeconfigVolume` helper

### Documentation

- **`README.md`**
  - Added comprehensive documentation section for the `volume` provider
  - Included both CLI and values file examples
  - Documented use cases and benefits

## Usage Example

### Values file
```yaml
kubeconfig:
  provider: volume
  volume:
    path: /home/node/.kube/config
    volumeSpec:
      name: kubeconfig
      secret:
        secretName: my-kubeconfig-secret
    volumeMountSpec:
      name: kubeconfig
      mountPath: /home/node/.kube
      readOnly: true
```

### Using Helm CLI
```bash
helm install mcp-server-k8s ./helm-chart \
  --set kubeconfig.provider=volume \
  --set kubeconfig.volume.path=/home/node/.kube/config \
  --set kubeconfig.volume.volumeSpec.name=kubeconfig \
  --set kubeconfig.volume.volumeSpec.secret.secretName=my-kubeconfig-secret \
  --set kubeconfig.volume.volumeMountSpec.name=kubeconfig \
  --set kubeconfig.volume.volumeMountSpec.mountPath=/home/node/.kube \
  --set kubeconfig.volume.volumeMountSpec.readOnly=true
```

## Use Cases

- External secret management integration
- GitOps workflows with Sealed Secrets
- Pre-existing kubeconfig infrastructure

**Note**: Tested helm chart's installation and used the configured mcp server in a kubernetes cluster successfully. Please feel free to add or provide suggestions. Thanks!