### PR TITLE
Add writable AWS credentials volume for EKS multi-account setups

### DIFF
--- a/helm-chart/examples/aws-multi-cluster.yaml
+++ b/helm-chart/examples/aws-multi-cluster.yaml
@@ -37,6 +37,8 @@ kubeconfig:
   initContainer:
     maxRetries: 3
     retryDelay: 10
+    # Pin AWS CLI to a specific version for reproducibility
+    imageTag: "2.15.0"
     resources:
       limits:
         cpu: 250m

--- a/helm-chart/examples/production-complete.yaml
+++ b/helm-chart/examples/production-complete.yaml
@@ -51,6 +51,18 @@ transport:
 # AWS EKS multi-cluster configuration
 kubeconfig:
   provider: "aws"
+  initContainer:
+    # Pin AWS CLI to a specific version for reproducibility
+    imageTag: "2.15.0"
+    maxRetries: 3
+    retryDelay: 10
+    resources:
+      limits:
+        cpu: 250m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
   aws:
     clusters:
       # Production US-East cluster

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -89,9 +89,12 @@ Get the appropriate init container image based on provider with architecture sup
 {{- else }}
 {{- $baseImage = "alpine" }}
 {{- end }}
+{{- $tag := .Values.kubeconfig.initContainer.imageTag | default "" }}
 {{- if and .Values.image.architectures .Values.image.architecture }}
-{{- $archTag := index .Values.image.architectures .Values.image.architecture | default "latest" }}
-{{- printf "%s:%s" $baseImage $archTag }}
+{{- $tag = index .Values.image.architectures .Values.image.architecture | default $tag }}
+{{- end }}
+{{- if $tag }}
+{{- printf "%s:%s" $baseImage $tag }}
 {{- else }}
 {{- printf "%s:latest" $baseImage }}
 {{- end }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -75,6 +75,10 @@ spec:
               mountPath: /kubeconfig
             - name: kubeconfig-scripts
               mountPath: /scripts
+            {{- if eq .Values.kubeconfig.provider "aws" }}
+            - name: aws-credentials
+              mountPath: /.aws
+            {{- end }}
           resources:
             {{- toYaml .Values.kubeconfig.initContainer.resources | nindent 12 }}
         {{- end }}
@@ -154,6 +158,10 @@ spec:
               {{- else if .Values.kubeconfig.volume.volumeMountSpec }}
             {{- list .Values.kubeconfig.volume.volumeMountSpec | toYaml | nindent 12 }}
               {{- end }}
+            {{- if eq .Values.kubeconfig.provider "aws" }}
+            - name: aws-credentials
+              mountPath: /home/node/.aws
+            {{- end }}
             {{- end }}
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -185,6 +193,10 @@ spec:
           configMap:
             name: {{ include "mcp-server-kubernetes.fullname" . }}-scripts
             defaultMode: 0755
+        {{- if eq .Values.kubeconfig.provider "aws" }}
+        - name: aws-credentials
+          emptyDir: {}
+        {{- end }}
         {{- else if eq .Values.kubeconfig.provider "content" }}
         - name: kubeconfig-volume
           secret:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -168,6 +168,12 @@ kubeconfig:
   initContainer:
     maxRetries: 3
     retryDelay: 10
+    # Image tag for the init container (defaults to "latest" if not set)
+    # Recommended to pin to a specific version for production
+    imageTag: ""
+    # Example:
+    # imageTag: "2.15.0"  # for AWS CLI
+    # imageTag: "slim"    # for GCP cloud-sdk
     resources:
       limits:
         cpu: 100m


### PR DESCRIPTION

When using AWS EKS provider with readOnlyRootFilesystem: true, both the
init container and main container fail because AWS CLI needs to write
to .aws directories for credentials caching and config files.

Changes:
- Add aws-credentials emptyDir volume mounted at /.aws (init container)
  and /home/node/.aws (main container) when using AWS provider
- Add configurable imageTag for init container (defaults to "latest")
  to allow pinning specific versions for production environments
- Update AWS examples to demonstrate imageTag usage

Fixes issue with "[Errno 30] Read-only file system: '/.aws'" errors
in multi-account, multi-cluster AWS EKS setups.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Flux159/mcp-server-kubernetes/pull/266).
* #271
* __->__ #266