### PR TITLE
Fix authentication priority order in docs

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -23,11 +23,12 @@ If you have large clusters or see a `spawnSync ENOBFUS` error, you may need to s
 The server supports multiple authentication methods with the following priority order:
 
 1. **`KUBECONFIG_YAML`** – Full config as YAML string
-2. **In-cluster** (if running in a pod)
-3. **`KUBECONFIG_JSON`** – Full config as JSON string
-4. **`K8S_SERVER` + `K8S_TOKEN`** – Minimal env-based config
+2. **`KUBECONFIG_JSON`** – Full config as JSON string
+3. **`K8S_SERVER` + `K8S_TOKEN`** – Minimal env-based config
+4. **In-cluster** (if running in a pod)
 5. **`KUBECONFIG_PATH`** – Custom kubeconfig file path
-6. **Default file** – `~/.kube/config`
+6. **`KUBECONFIG`** – Standard kubeconfig env var
+7. **Default file** – `~/.kube/config`
 
 ### Environment Variables
 


### PR DESCRIPTION
## Summary
- Fixes the authentication priority order in `ADVANCED_README.md` to match the actual code in `kubernetes-manager.ts`
- Moves `KUBECONFIG_JSON` and `K8S_SERVER + K8S_TOKEN` above in-cluster auth (they were incorrectly listed after it)
- Adds the missing `KUBECONFIG` env var (standard kubeconfig path) as priority 6, which was undocumented

The correct order per the code is:
1. `KUBECONFIG_YAML`
2. `KUBECONFIG_JSON`
3. `K8S_SERVER` + `K8S_TOKEN`
4. In-cluster
5. `KUBECONFIG_PATH`
6. `KUBECONFIG`
7. Default `~/.kube/config`

Fixes #277

## Test plan
- [x] Verified priority order matches `src/utils/kubernetes-manager.ts` constructor logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)