### PR TITLE
docs: add AdaL CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,21 @@ npx mcp-chat --config "%APPDATA%\Claude\claude_desktop_config.json"
 gemini extensions install https://github.com/Flux159/mcp-server-kubernetes
 ```
 
+### AdaL CLI
+
+[AdaL CLI](https://sylph.ai/) is a unified AI agent for software engineering with built-in [MCP support](https://docs.sylph.ai/features/mcp-support-proposed). Add the Kubernetes MCP server directly from the AdaL CLI prompt:
+
+```text
+# Run inside the AdaL CLI prompt:
+/mcp add kubernetes --command npx --args "-y,mcp-server-kubernetes"
+```
+
+For non-destructive mode:
+
+```text
+/mcp add kubernetes --command npx --args "-y,mcp-server-kubernetes" --env "ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS=true"
+```
+
 ## Features
 
 - [x] Connect to a Kubernetes cluster


### PR DESCRIPTION
## Summary

Add [AdaL CLI](https://sylph.ai/) as an MCP client option in the installation documentation. AdaL CLI is a unified AI agent for software engineering with built-in [MCP support](https://docs.sylph.ai/features/mcp-support-proposed).

## Changes

- Added "AdaL CLI" section to `README.md` after the Gemini CLI section, including:
  - Standard `/mcp add` command for the Kubernetes MCP server
  - Non-destructive mode variant with `ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS` env flag

## Formatting

- Uses `text` code fences (not `bash`) since the commands run inside the AdaL CLI prompt, not a shell.
- AdaL CLI is placed last, following the convention of appending new clients after existing ones.

🌸 Generated with [AdaL](https://github.com/adal-cli/)
