### PR TITLE
fix: Gemini CLI installation and automated version updates

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -92,7 +92,7 @@ jobs:
           # Update the version in all files using the npm script
           npm run version:update ${{ steps.version.outputs.current-version }}
 
-          git add package.json manifest.json CITATION.cff README.md
+          git add package.json manifest.json CITATION.cff README.md gemini-extension.json
           git commit -m "Bump version to ${{ steps.version.outputs.current-version }}"
 
           # Create and push the tag
@@ -134,11 +134,15 @@ jobs:
       - name: Build dxt
         run: |
           bun run buildmcpb
+          # Create a standard zip archive for Gemini CLI and other tools
+          git archive --format=zip -o mcp-server-kubernetes.zip HEAD
 
-      - name: Upload Release Asset
+      - name: Upload Release Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload v${{ steps.version.outputs.current-version }} mcp-server-kubernetes.mcpb --clobber
+        run: |
+          gh release upload v${{ steps.version.outputs.current-version }} mcp-server-kubernetes.mcpb --clobber
+          gh release upload v${{ steps.version.outputs.current-version }} mcp-server-kubernetes.zip --clobber
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -41,6 +41,14 @@ const files = [
   {
     path: 'README.md',
     update: (content) => content.replace(/version = \{\{\{VERSION\}\}\}/g, `version = {${version}}`)
+  },
+  {
+    path: 'gemini-extension.json',
+    update: (content) => {
+      const ext = JSON.parse(content);
+      ext.version = version;
+      return JSON.stringify(ext, null, 2) + '\n';
+    }
   }
 ];
 


### PR DESCRIPTION
This PR addresses two issues related to the Gemini CLI extension:


   1. Installation Failure from GitHub Releases: Currently, gemini extensions install
      https://github.com/Flux159/mcp-server-kubernetes fails because the CLI attempts to download and extract the .mcpb asset,
      which is an unsupported format for the CLI's extractor. This PR updates the cd.yml workflow to generate and upload a
      standard .zip archive of the source code to each release, ensuring smooth installation for Gemini CLI users.
   2. Stale Extension Version: The gemini-extension.json metadata was not being synchronized with new releases. This PR updates
      the update-version.js script to include this file in the automated versioning process and ensures it is staged during the
      release commit.


  Changes:
   - Workflow (`.github/workflows/cd.yml`):
     - Added a step to create mcp-server-kubernetes.zip using git archive.
     - Updated the release step to upload both the .mcpb and .zip assets.
     - Added gemini-extension.json to the files staged during the version bump commit.
   - Versioning Script (`scripts/update-version.js`):
     - Added gemini-extension.json to the list of files updated with the new version string.


  Verification:
   - Manually verified that gemini-extension.json follows the same JSON structure as package.json and manifest.json for version
     updates.
   - Verified that git archive correctly packages the repository contents for extraction.