### PR TITLE
feat: add code mode for token-sensitive users (save 65-99% token)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,8 +75,13 @@ import { registerPromptHandlers } from "./prompts/index.js";
 import { ping, pingSchema } from "./tools/ping.js";
 import { startStreamableHTTPServer } from "./utils/streamable-http.js";
 import { withTelemetry } from "./middleware/telemetry-middleware.js";
+import {
+  kubectlCodeMode,
+  kubectlCodeModeSchema,
+} from "./tools/kubectl-code-mode.js";
 
 // Check environment variables for tool filtering
+const enableCodeMode = process.env.ENABLE_CODE_MODE === "true";
 const allowOnlyReadonlyTools = process.env.ALLOW_ONLY_READONLY_TOOLS === "true";
 const allowedToolsEnv = process.env.ALLOWED_TOOLS;
 const nonDestructiveTools =
@@ -191,6 +196,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     );
   } else {
     tools = allTools;
+  }
+
+  // Append code-mode tools when enabled
+  if (enableCodeMode) {
+    tools = [...tools, kubectlCodeModeSchema];
   }
 
   return { tools };
@@ -382,6 +392,18 @@ server.setRequestHandler(
           output: (input as { output?: string }).output,
           context: (input as { context?: string }).context,
         });
+      }
+
+      // Code mode tools
+      if (name === "kubectl_code_mode" && enableCodeMode) {
+        return await kubectlCodeMode(
+          input as {
+            args: string;
+            language?: string;
+            code: string;
+            context?: string;
+          }
+        );
       }
 
       // Handle specific non-kubectl operations

--- a/src/tools/kubectl-code-mode.ts
+++ b/src/tools/kubectl-code-mode.ts
@@ -1,0 +1,190 @@
+import { execFileSync } from "node:child_process";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { getSpawnMaxBuffer } from "../config/max-buffer.js";
+import { PolyglotExecutor } from "../utils/executor.js";
+import { getAvailableLanguages, detectRuntimes } from "../utils/runtime.js";
+import { contextParameter } from "../models/common-parameters.js";
+import type { Language } from "../utils/runtime.js";
+
+const runtimes = detectRuntimes();
+const executor = new PolyglotExecutor({ runtimes });
+const availableLanguages = getAvailableLanguages(runtimes);
+
+export const kubectlCodeModeSchema = {
+  name: "kubectl_code_mode",
+  description:
+    "Run a kubectl command and process its output with code in a sandbox. " +
+    "The raw kubectl output is available as the DATA variable (string). " +
+    "Only your script's stdout enters context — raw output stays internal. " +
+    "Use when kubectl output would be large (list all pods, logs, describe nodes). " +
+    `Available languages: ${availableLanguages.join(", ")}.`,
+  annotations: {
+    readOnlyHint: true,
+  },
+  inputSchema: {
+    type: "object",
+    properties: {
+      args: {
+        type: "string",
+        description:
+          "kubectl arguments as a single string, e.g. 'get pods -A -o json', " +
+          "'logs my-pod --tail=500', 'describe node my-node'. " +
+          "Do NOT include 'kubectl' prefix.",
+      },
+      language: {
+        type: "string",
+        enum: availableLanguages,
+        description: "Language for the processing script.",
+        default: "javascript",
+      },
+      code: {
+        type: "string",
+        description:
+          "Code to process the kubectl output. The raw output is available as " +
+          "the DATA variable (string). Print your summary to stdout via " +
+          "console.log (JS/TS), print (Python), echo (shell), etc. " +
+          "Only stdout enters context.",
+      },
+      context: contextParameter,
+    },
+    required: ["args", "code"],
+  },
+} as const;
+
+export async function kubectlCodeMode(input: {
+  args: string;
+  language?: string;
+  code: string;
+  context?: string;
+}): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const language = (input.language ?? "javascript") as Language;
+
+  if (!availableLanguages.includes(language)) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Language "${language}" is not available. Available: ${availableLanguages.join(", ")}`,
+    );
+  }
+
+  // 1. Build kubectl command args
+  const kubectlArgs = parseArgs(input.args);
+  if (input.context) {
+    kubectlArgs.push("--context", input.context);
+  }
+
+  // 2. Run kubectl, capture raw output
+  let rawOutput: string;
+  try {
+    rawOutput = execFileSync("kubectl", kubectlArgs, {
+      encoding: "utf8",
+      maxBuffer: Math.max(getSpawnMaxBuffer(), 50 * 1024 * 1024), // 50MB — code-mode handles large outputs
+      env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
+    });
+  } catch (error: any) {
+    throw new McpError(
+      ErrorCode.InternalError,
+      `kubectl failed: ${error.stderr || error.message}`,
+    );
+  }
+
+  const rawBytes = Buffer.byteLength(rawOutput);
+
+  // 3. Wrap user code with DATA injection
+  const wrappedCode = injectData(language, rawOutput, input.code);
+
+  // 4. Execute in sandbox
+  const result = await executor.execute({
+    language,
+    code: wrappedCode,
+    timeout: 30_000,
+  });
+
+  // 5. Build response
+  const stdout = result.stdout || "(no output — make sure your code prints to stdout)";
+  const returnedBytes = Buffer.byteLength(stdout);
+
+  const parts: string[] = [stdout];
+
+  if (result.stderr && result.exitCode !== 0) {
+    parts.push(`\nstderr: ${result.stderr}`);
+  }
+  if (result.timedOut) {
+    parts.push("\n(script timed out after 30s)");
+  }
+
+  // Inline stat so the LLM sees the savings per call
+  const kb = (b: number) => b < 1024 ? `${b}B` : `${(b / 1024).toFixed(1)}KB`;
+  const pct = rawBytes > 0 ? ((1 - returnedBytes / rawBytes) * 100).toFixed(1) : "0";
+  parts.push(`\n[code-mode: ${kb(rawBytes)} → ${kb(returnedBytes)} (${pct}% reduction)]`);
+
+  return {
+    content: [{ type: "text", text: parts.join("") }],
+  };
+}
+
+// Split args string into array, respecting quotes
+function parseArgs(argsStr: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let inQuote: string | null = null;
+
+  for (const ch of argsStr) {
+    if (inQuote) {
+      if (ch === inQuote) {
+        inQuote = null;
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"' || ch === "'") {
+      inQuote = ch;
+    } else if (ch === " " || ch === "\t") {
+      if (current) {
+        args.push(current);
+        current = "";
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current) args.push(current);
+  return args;
+}
+
+// Inject raw kubectl output as DATA variable for each language
+function injectData(language: Language, data: string, userCode: string): string {
+  const escaped = JSON.stringify(data);
+
+  switch (language) {
+    case "javascript":
+    case "typescript":
+      return `const DATA = ${escaped};\n${userCode}`;
+
+    case "python":
+      return `import json as _json\nDATA = _json.loads(${JSON.stringify(escaped)})\n${userCode}`;
+
+    case "shell": {
+      return `DATA=$(cat <<'__K8S_CODE_MODE_EOF__'\n${data}\n__K8S_CODE_MODE_EOF__\n)\n${userCode}`;
+    }
+
+    case "ruby":
+      return `DATA = ${escaped}\n${userCode}`;
+
+    case "go":
+      return `package main\n\nimport "fmt"\n\nvar DATA = ${escaped}\n\nfunc main() {\n\t_ = fmt.Sprint()\n${userCode}\n}\n`;
+
+    case "rust":
+      return `fn main() {\n    let data = ${escaped};\n${userCode}\n}\n`;
+
+    case "php":
+      return `<?php\n$DATA = ${escaped};\n${userCode}`;
+
+    case "perl":
+      return `my $DATA = ${escaped};\n${userCode}`;
+
+    case "r":
+      return `DATA <- ${escaped}\n${userCode}`;
+
+    case "elixir":
+      return `data = ${escaped}\n${userCode}`;
+  }
+}

--- a/src/utils/executor.ts
+++ b/src/utils/executor.ts
@@ -1,0 +1,295 @@
+import { spawn, execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  detectRuntimes,
+  buildCommand,
+  type RuntimeMap,
+  type Language,
+} from "./runtime.js";
+
+const isWin = process.platform === "win32";
+
+function killTree(proc: ReturnType<typeof spawn>): void {
+  if (isWin && proc.pid) {
+    try {
+      execSync(`taskkill /F /T /PID ${proc.pid}`, { stdio: "pipe" });
+    } catch { /* already dead */ }
+  } else {
+    proc.kill("SIGKILL");
+  }
+}
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  timedOut: boolean;
+}
+
+interface ExecuteOptions {
+  language: Language;
+  code: string;
+  timeout?: number;
+}
+
+export class PolyglotExecutor {
+  #maxOutputBytes: number;
+  #hardCapBytes: number;
+  #runtimes: RuntimeMap;
+
+  constructor(opts?: {
+    maxOutputBytes?: number;
+    hardCapBytes?: number;
+    runtimes?: RuntimeMap;
+  }) {
+    this.#maxOutputBytes = opts?.maxOutputBytes ?? 102_400;
+    this.#hardCapBytes = opts?.hardCapBytes ?? 100 * 1024 * 1024;
+    this.#runtimes = opts?.runtimes ?? detectRuntimes();
+  }
+
+  get runtimes(): RuntimeMap {
+    return { ...this.#runtimes };
+  }
+
+  async execute(opts: ExecuteOptions): Promise<ExecResult> {
+    const { language, code, timeout = 30_000 } = opts;
+    const tmpDir = mkdtempSync(join(tmpdir(), "k8s-code-mode-"));
+
+    try {
+      const filePath = this.#writeScript(tmpDir, code, language);
+      const cmd = buildCommand(this.#runtimes, language, filePath);
+
+      if (cmd[0] === "__rust_compile_run__") {
+        return await this.#compileAndRun(filePath, tmpDir, timeout);
+      }
+
+      return await this.#spawn(cmd, tmpDir, timeout);
+    } finally {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch { /* OS will clean up */ }
+    }
+  }
+
+  #writeScript(tmpDir: string, code: string, language: Language): string {
+    const extMap: Record<Language, string> = {
+      javascript: "js",
+      typescript: "ts",
+      python: "py",
+      shell: "sh",
+      ruby: "rb",
+      go: "go",
+      rust: "rs",
+      php: "php",
+      perl: "pl",
+      r: "R",
+      elixir: "exs",
+    };
+
+    if (language === "go" && !code.includes("package ")) {
+      code = `package main\n\nimport "fmt"\n\nfunc main() {\n${code}\n}\n`;
+    }
+
+    if (language === "php" && !code.trimStart().startsWith("<?")) {
+      code = `<?php\n${code}`;
+    }
+
+    const fp = join(tmpDir, `script.${extMap[language]}`);
+    if (language === "shell") {
+      writeFileSync(fp, code, { encoding: "utf-8", mode: 0o700 });
+    } else {
+      writeFileSync(fp, code, "utf-8");
+    }
+    return fp;
+  }
+
+  async #compileAndRun(
+    srcPath: string,
+    cwd: string,
+    timeout: number,
+  ): Promise<ExecResult> {
+    const binSuffix = isWin ? ".exe" : "";
+    const binPath = srcPath.replace(/\.rs$/, "") + binSuffix;
+
+    try {
+      execSync(`rustc ${srcPath} -o ${binPath}`, {
+        cwd,
+        timeout: Math.min(timeout, 30_000),
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? (err as any).stderr || err.message : String(err);
+      return {
+        stdout: "",
+        stderr: `Compilation failed:\n${message}`,
+        exitCode: 1,
+        timedOut: false,
+      };
+    }
+
+    return this.#spawn([binPath], cwd, timeout);
+  }
+
+  static smartTruncate(raw: string, max: number): string {
+    if (Buffer.byteLength(raw) <= max) return raw;
+
+    const lines = raw.split("\n");
+    const headBudget = Math.floor(max * 0.6);
+    const tailBudget = max - headBudget;
+
+    const headLines: string[] = [];
+    let headBytes = 0;
+    for (const line of lines) {
+      const lineBytes = Buffer.byteLength(line) + 1;
+      if (headBytes + lineBytes > headBudget) break;
+      headLines.push(line);
+      headBytes += lineBytes;
+    }
+
+    const tailLines: string[] = [];
+    let tailBytes = 0;
+    for (let i = lines.length - 1; i >= headLines.length; i--) {
+      const lineBytes = Buffer.byteLength(lines[i]) + 1;
+      if (tailBytes + lineBytes > tailBudget) break;
+      tailLines.unshift(lines[i]);
+      tailBytes += lineBytes;
+    }
+
+    const skippedLines = lines.length - headLines.length - tailLines.length;
+    const skippedBytes = Buffer.byteLength(raw) - headBytes - tailBytes;
+
+    const separator = `\n\n... [${skippedLines} lines / ${(skippedBytes / 1024).toFixed(1)}KB truncated — showing first ${headLines.length} + last ${tailLines.length} lines] ...\n\n`;
+
+    return headLines.join("\n") + separator + tailLines.join("\n");
+  }
+
+  async #spawn(
+    cmd: string[],
+    cwd: string,
+    timeout: number,
+  ): Promise<ExecResult> {
+    return new Promise((res) => {
+      const needsShell = isWin && ["tsx", "ts-node", "elixir"].includes(cmd[0]);
+
+      const spawnCmd = cmd[0];
+      const spawnArgs = isWin
+        ? cmd.slice(1).map(a => a.replace(/\\/g, "/"))
+        : cmd.slice(1);
+
+      const proc = spawn(spawnCmd, spawnArgs, {
+        cwd,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: this.#buildSafeEnv(cwd),
+        shell: needsShell,
+      });
+
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        killTree(proc);
+      }, timeout);
+
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let totalBytes = 0;
+      let capExceeded = false;
+
+      proc.stdout!.on("data", (chunk: Buffer) => {
+        totalBytes += chunk.length;
+        if (totalBytes <= this.#hardCapBytes) {
+          stdoutChunks.push(chunk);
+        } else if (!capExceeded) {
+          capExceeded = true;
+          killTree(proc);
+        }
+      });
+
+      proc.stderr!.on("data", (chunk: Buffer) => {
+        totalBytes += chunk.length;
+        if (totalBytes <= this.#hardCapBytes) {
+          stderrChunks.push(chunk);
+        } else if (!capExceeded) {
+          capExceeded = true;
+          killTree(proc);
+        }
+      });
+
+      proc.on("close", (exitCode) => {
+        clearTimeout(timer);
+        const rawStdout = Buffer.concat(stdoutChunks).toString("utf-8");
+        let rawStderr = Buffer.concat(stderrChunks).toString("utf-8");
+
+        if (capExceeded) {
+          rawStderr += `\n[output capped at ${(this.#hardCapBytes / 1024 / 1024).toFixed(0)}MB — process killed]`;
+        }
+
+        const max = this.#maxOutputBytes;
+        const stdout = PolyglotExecutor.smartTruncate(rawStdout, max);
+        const stderr = PolyglotExecutor.smartTruncate(rawStderr, max);
+
+        res({
+          stdout,
+          stderr,
+          exitCode: timedOut ? 1 : (exitCode ?? 1),
+          timedOut,
+        });
+      });
+
+      proc.on("error", (err) => {
+        clearTimeout(timer);
+        res({
+          stdout: "",
+          stderr: err.message,
+          exitCode: 1,
+          timedOut: false,
+        });
+      });
+    });
+  }
+
+  #buildSafeEnv(tmpDir: string): Record<string, string> {
+    const realHome = process.env.HOME ?? process.env.USERPROFILE ?? tmpDir;
+
+    const passthrough = [
+      "KUBECONFIG", "K8S_CONTEXT", "K8S_NAMESPACE",
+      "GH_TOKEN", "GITHUB_TOKEN",
+      "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+      "AWS_REGION", "AWS_DEFAULT_REGION", "AWS_PROFILE",
+      "GOOGLE_APPLICATION_CREDENTIALS",
+      "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+      "SSL_CERT_FILE", "CURL_CA_BUNDLE",
+      "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+      "SSH_AUTH_SOCK", "SSH_AGENT_PID",
+    ];
+
+    const env: Record<string, string> = {
+      PATH: process.env.PATH ?? (isWin ? "" : "/usr/local/bin:/usr/bin:/bin"),
+      HOME: realHome,
+      TMPDIR: tmpDir,
+      LANG: "en_US.UTF-8",
+      PYTHONDONTWRITEBYTECODE: "1",
+      PYTHONUNBUFFERED: "1",
+      PYTHONUTF8: "1",
+      NO_COLOR: "1",
+    };
+
+    if (isWin) {
+      const winVars = [
+        "SYSTEMROOT", "SystemRoot", "COMSPEC", "PATHEXT",
+        "USERPROFILE", "APPDATA", "LOCALAPPDATA", "TEMP", "TMP",
+      ];
+      for (const key of winVars) {
+        if (process.env[key]) env[key] = process.env[key]!;
+      }
+    }
+
+    for (const key of passthrough) {
+      if (process.env[key]) env[key] = process.env[key]!;
+    }
+
+    return env;
+  }
+}

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -1,0 +1,144 @@
+import { execSync } from "node:child_process";
+
+export type Language =
+  | "javascript"
+  | "typescript"
+  | "python"
+  | "shell"
+  | "ruby"
+  | "go"
+  | "rust"
+  | "php"
+  | "perl"
+  | "r"
+  | "elixir";
+
+export interface RuntimeMap {
+  javascript: string;
+  typescript: string | null;
+  python: string | null;
+  shell: string;
+  ruby: string | null;
+  go: string | null;
+  rust: string | null;
+  php: string | null;
+  perl: string | null;
+  r: string | null;
+  elixir: string | null;
+}
+
+const isWindows = process.platform === "win32";
+
+function commandExists(cmd: string): boolean {
+  try {
+    const check = isWindows ? `where ${cmd}` : `command -v ${cmd}`;
+    execSync(check, { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function detectRuntimes(): RuntimeMap {
+  const hasBun = commandExists("bun");
+
+  return {
+    javascript: hasBun ? "bun" : "node",
+    typescript: hasBun
+      ? "bun"
+      : commandExists("tsx")
+        ? "tsx"
+        : commandExists("ts-node")
+          ? "ts-node"
+          : null,
+    python: commandExists("python3")
+      ? "python3"
+      : commandExists("python")
+        ? "python"
+        : null,
+    shell: isWindows
+      ? (commandExists("bash") ? "bash" : commandExists("sh") ? "sh" : "cmd.exe")
+      : commandExists("bash") ? "bash" : "sh",
+    ruby: commandExists("ruby") ? "ruby" : null,
+    go: commandExists("go") ? "go" : null,
+    rust: commandExists("rustc") ? "rustc" : null,
+    php: commandExists("php") ? "php" : null,
+    perl: commandExists("perl") ? "perl" : null,
+    r: commandExists("Rscript")
+      ? "Rscript"
+      : commandExists("r")
+        ? "r"
+        : null,
+    elixir: commandExists("elixir") ? "elixir" : null,
+  };
+}
+
+export function getAvailableLanguages(runtimes: RuntimeMap): Language[] {
+  const langs: Language[] = ["javascript", "shell"];
+  if (runtimes.typescript) langs.push("typescript");
+  if (runtimes.python) langs.push("python");
+  if (runtimes.ruby) langs.push("ruby");
+  if (runtimes.go) langs.push("go");
+  if (runtimes.rust) langs.push("rust");
+  if (runtimes.php) langs.push("php");
+  if (runtimes.perl) langs.push("perl");
+  if (runtimes.r) langs.push("r");
+  if (runtimes.elixir) langs.push("elixir");
+  return langs;
+}
+
+export function buildCommand(
+  runtimes: RuntimeMap,
+  language: Language,
+  filePath: string,
+): string[] {
+  switch (language) {
+    case "javascript":
+      return runtimes.javascript === "bun"
+        ? ["bun", "run", filePath]
+        : ["node", filePath];
+
+    case "typescript":
+      if (!runtimes.typescript) {
+        throw new Error("No TypeScript runtime. Install bun, tsx, or ts-node.");
+      }
+      if (runtimes.typescript === "bun") return ["bun", "run", filePath];
+      if (runtimes.typescript === "tsx") return ["tsx", filePath];
+      return ["ts-node", filePath];
+
+    case "python":
+      if (!runtimes.python) throw new Error("Python not available.");
+      return [runtimes.python, filePath];
+
+    case "shell":
+      return [runtimes.shell, filePath];
+
+    case "ruby":
+      if (!runtimes.ruby) throw new Error("Ruby not available.");
+      return [runtimes.ruby, filePath];
+
+    case "go":
+      if (!runtimes.go) throw new Error("Go not available.");
+      return ["go", "run", filePath];
+
+    case "rust":
+      if (!runtimes.rust) throw new Error("Rust not available. Install via https://rustup.rs");
+      return ["__rust_compile_run__", filePath];
+
+    case "php":
+      if (!runtimes.php) throw new Error("PHP not available.");
+      return ["php", filePath];
+
+    case "perl":
+      if (!runtimes.perl) throw new Error("Perl not available.");
+      return ["perl", filePath];
+
+    case "r":
+      if (!runtimes.r) throw new Error("R not available.");
+      return [runtimes.r, filePath];
+
+    case "elixir":
+      if (!runtimes.elixir) throw new Error("Elixir not available.");
+      return ["elixir", filePath];
+  }
+}

--- a/tests/benchmark-code-mode.ts
+++ b/tests/benchmark-code-mode.ts
@@ -1,0 +1,328 @@
+/**
+ * Benchmark: measure actual byte savings of code-mode vs existing tool responses.
+ *
+ * "Before" simulates what kubectl_get / list_api_resources actually returns
+ * (already formatted, not raw kubectl JSON). "After" shows what kubectl_code_mode
+ * returns for the same query. Both sides use the exact same kubectl command.
+ *
+ * Usage:
+ *   KUBECONFIG=~/.kube/config npx tsx tests/benchmark-code-mode.ts
+ *
+ * Requires a running cluster.
+ */
+
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { PolyglotExecutor } from "../src/utils/executor.js";
+import { detectRuntimes, getAvailableLanguages } from "../src/utils/runtime.js";
+
+const runtimes = detectRuntimes();
+const executor = new PolyglotExecutor({ runtimes });
+const langs = getAvailableLanguages(runtimes);
+
+console.log("Available languages:", langs.join(", "));
+console.log("");
+
+// ─── Helpers ───
+
+function kubectl(args: string): string {
+  const parts = args.split(/\s+/);
+  return execFileSync("kubectl", parts, {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+    env: { ...process.env },
+  });
+}
+
+function injectData(data: string, code: string): string {
+  const escaped = JSON.stringify(data);
+  return `const DATA = ${escaped};\n${code}`;
+}
+
+// Simulate what kubectl_get returns for list operations (src/tools/kubectl-get.ts:176-228).
+// It parses the raw JSON and returns { items: [{ name, namespace, kind, status, createdAt }] }
+// for non-event resources, and { events: [{ type, reason, message, involvedObject, ... }] }
+// for events.
+function simulateKubectlGetResponse(rawJson: string, resourceType: string): string {
+  const parsed = JSON.parse(rawJson);
+  if (!parsed.kind?.endsWith("List") || !parsed.items) return rawJson;
+
+  if (resourceType === "events") {
+    const formattedEvents = parsed.items.map((event: any) => ({
+      type: event.type || "",
+      reason: event.reason || "",
+      message: event.message || "",
+      involvedObject: {
+        kind: event.involvedObject?.kind || "",
+        name: event.involvedObject?.name || "",
+        namespace: event.involvedObject?.namespace || "",
+      },
+      firstTimestamp: event.firstTimestamp || "",
+      lastTimestamp: event.lastTimestamp || "",
+      count: event.count || 0,
+    }));
+    return JSON.stringify({ events: formattedEvents }, null, 2);
+  }
+
+  const items = parsed.items.map((item: any) => ({
+    name: item.metadata?.name || "",
+    namespace: item.metadata?.namespace || "",
+    kind: item.kind || resourceType,
+    status: getSimpleStatus(item, resourceType),
+    createdAt: item.metadata?.creationTimestamp,
+  }));
+  return JSON.stringify({ items }, null, 2);
+}
+
+// Simplified version of getResourceStatus from kubectl-get.ts
+function getSimpleStatus(resource: any, resourceType: string): string {
+  if (resourceType === "pods" || resourceType === "pod") {
+    return resource.status?.phase || "Unknown";
+  }
+  if (resource.status?.readyReplicas !== undefined) {
+    return `${resource.status.readyReplicas || 0}/${resource.status.replicas || 0} ready`;
+  }
+  if (resource.spec?.type) return resource.spec.type;
+  if (resource.status?.conditions) {
+    const ready = resource.status.conditions.find((c: any) => c.type === "Ready");
+    if (ready) return ready.status === "True" ? "Ready" : "NotReady";
+  }
+  if (resource.status?.phase) return resource.status.phase;
+  return "Active";
+}
+
+interface TestCase {
+  name: string;
+  kubectlArgs: string;
+  resourceType: string; // used to simulate kubectl_get formatting
+  isApiResources?: boolean; // list_api_resources returns raw text, not JSON
+  code: string;
+}
+
+// ─── Test cases ───
+// Each case uses the exact same kubectl command for both "before" and "after".
+// "Before" = what kubectl_get actually returns (already formatted).
+// "After"  = what kubectl_code_mode returns (script stdout only).
+
+const testCases: TestCase[] = [
+  // Mimics: kubectl_get({ resourceType: "pods", allNamespaces: true, output: "json" })
+  // kubectl_get returns: { items: [{ name, namespace, kind, status, createdAt }, ...] }
+  {
+    name: "List all pods (all namespaces)",
+    kubectlArgs: "get pods -A -o json",
+    resourceType: "pods",
+    code: `
+const pods = JSON.parse(DATA).items;
+const summary = pods.map(p => {
+  const phase = p.status?.phase || "Unknown";
+  const restarts = (p.status?.containerStatuses || []).reduce((s, c) => s + c.restartCount, 0);
+  return p.metadata.namespace + "/" + p.metadata.name + " " + phase + " restarts=" + restarts;
+});
+console.log("Pods: " + pods.length);
+summary.forEach(l => console.log(l));
+`,
+  },
+  // Mimics: kubectl_get({ resourceType: "deployments", allNamespaces: true, output: "json" })
+  // kubectl_get returns: { items: [{ name, namespace, kind, status, createdAt }, ...] }
+  {
+    name: "List all deployments (all namespaces)",
+    kubectlArgs: "get deployments -A -o json",
+    resourceType: "deployments",
+    code: `
+const deps = JSON.parse(DATA).items;
+deps.forEach(d => {
+  const ready = d.status?.readyReplicas || 0;
+  const desired = d.spec?.replicas || 0;
+  console.log(d.metadata.namespace + "/" + d.metadata.name + " " + ready + "/" + desired);
+});
+console.log("Total: " + deps.length);
+`,
+  },
+  // Mimics: kubectl_get({ resourceType: "services", allNamespaces: true, output: "json" })
+  // kubectl_get returns: { items: [{ name, namespace, kind, status, createdAt }, ...] }
+  {
+    name: "List all services (all namespaces)",
+    kubectlArgs: "get services -A -o json",
+    resourceType: "services",
+    code: `
+const svcs = JSON.parse(DATA).items;
+svcs.forEach(s => {
+  const type = s.spec?.type || "ClusterIP";
+  const ports = (s.spec?.ports || []).map(p => p.port + "/" + p.protocol).join(",");
+  console.log(s.metadata.namespace + "/" + s.metadata.name + " " + type + " " + ports);
+});
+console.log("Total: " + svcs.length);
+`,
+  },
+  // Mimics: kubectl_get({ resourceType: "events", allNamespaces: true, output: "json" })
+  // kubectl_get returns: { events: [{ type, reason, message, involvedObject, timestamps, count }, ...] }
+  {
+    name: "List all events (all namespaces)",
+    kubectlArgs: "get events -A -o json",
+    resourceType: "events",
+    code: `
+const events = JSON.parse(DATA).items;
+const warnings = events.filter(e => e.type === "Warning");
+const recent = events.slice(-20);
+console.log("Events: " + events.length + " (" + warnings.length + " warnings)");
+console.log("\\nLast 20:");
+recent.forEach(e => {
+  console.log(e.type + " " + e.reason + " " + (e.involvedObject?.name || "") + ": " + (e.message || "").slice(0, 100));
+});
+`,
+  },
+  // Mimics: kubectl_get({ resourceType: "configmaps", allNamespaces: true, output: "json" })
+  // kubectl_get returns: { items: [{ name, namespace, kind, status, createdAt }, ...] }
+  {
+    name: "List all configmaps (all namespaces)",
+    kubectlArgs: "get configmaps -A -o json",
+    resourceType: "configmaps",
+    code: `
+const cms = JSON.parse(DATA).items;
+cms.forEach(c => {
+  const keys = Object.keys(c.data || {});
+  console.log(c.metadata.namespace + "/" + c.metadata.name + " keys=" + keys.length);
+});
+console.log("Total: " + cms.length);
+`,
+  },
+  // Mimics: kubectl_get({ resourceType: "nodes", output: "json" })
+  // kubectl_get returns: { items: [{ name, namespace, kind, status, createdAt }, ...] }
+  {
+    name: "List nodes",
+    kubectlArgs: "get nodes -o json",
+    resourceType: "nodes",
+    code: `
+const nodes = JSON.parse(DATA).items;
+nodes.forEach(n => {
+  const ready = (n.status?.conditions || []).find(c => c.type === "Ready");
+  const cpu = n.status?.capacity?.cpu || "?";
+  const mem = n.status?.capacity?.memory || "?";
+  console.log(n.metadata.name + " " + (ready?.status === "True" ? "Ready" : "NotReady") + " cpu=" + cpu + " mem=" + mem);
+});
+`,
+  },
+  // Mimics: list_api_resources({})
+  // list_api_resources returns raw text output (not JSON formatted)
+  {
+    name: "List API resources",
+    kubectlArgs: "api-resources",
+    resourceType: "",
+    isApiResources: true,
+    code: `
+const lines = DATA.split("\\n").filter(Boolean);
+console.log("API resource types: " + (lines.length - 1));
+console.log(lines[0]);
+`,
+  },
+];
+
+// ─── Run benchmark ───
+
+interface Result {
+  name: string;
+  kubectlArgs: string;
+  toolResponseBytes: number;
+  codeModeBytes: number;
+  reductionPct: string;
+  error?: string;
+}
+
+async function run() {
+  const results: Result[] = [];
+
+  for (const tc of testCases) {
+    process.stdout.write(`Running: ${tc.name}... `);
+
+    try {
+      // Run the same kubectl command for both sides
+      const rawOutput = kubectl(tc.kubectlArgs);
+
+      // "Before" — simulate what the existing MCP tool actually returns
+      const toolResponse = tc.isApiResources
+        ? rawOutput // list_api_resources returns raw text
+        : simulateKubectlGetResponse(rawOutput, tc.resourceType);
+      const toolResponseBytes = Buffer.byteLength(toolResponse);
+
+      // "After" — code-mode processes raw output, returns only script stdout
+      const wrappedCode = injectData(rawOutput, tc.code);
+      const execResult = await executor.execute({
+        language: "javascript",
+        code: wrappedCode,
+        timeout: 15_000,
+      });
+
+      const codeModeOutput = execResult.stdout || "";
+      const codeModeBytes = Buffer.byteLength(codeModeOutput);
+
+      const reductionPct = toolResponseBytes > 0
+        ? ((1 - codeModeBytes / toolResponseBytes) * 100).toFixed(1)
+        : "0";
+
+      results.push({
+        name: tc.name,
+        kubectlArgs: tc.kubectlArgs,
+        toolResponseBytes,
+        codeModeBytes,
+        reductionPct: reductionPct + "%",
+      });
+
+      console.log(`${kb(toolResponseBytes)} → ${kb(codeModeBytes)} (${reductionPct}%)`);
+
+      if (execResult.stderr && execResult.exitCode !== 0) {
+        console.log(`  stderr: ${execResult.stderr.slice(0, 200)}`);
+      }
+    } catch (err: any) {
+      console.log(`ERROR: ${err.message}`);
+      results.push({
+        name: tc.name,
+        kubectlArgs: tc.kubectlArgs,
+        toolResponseBytes: 0,
+        codeModeBytes: 0,
+        reductionPct: "N/A",
+        error: err.message,
+      });
+    }
+  }
+
+  // ─── Summary ───
+  console.log("\n\n## Benchmark Results\n");
+  console.log("| Test | Tool Response | Code-Mode Output | Reduction |");
+  console.log("|---|---|---|---|");
+  for (const r of results) {
+    console.log(
+      `| ${r.name} | ${kb(r.toolResponseBytes)} | ${kb(r.codeModeBytes)} | ${r.reductionPct} |`
+    );
+  }
+
+  const totalTool = results.reduce((s, r) => s + r.toolResponseBytes, 0);
+  const totalCode = results.reduce((s, r) => s + r.codeModeBytes, 0);
+  const totalPct = totalTool > 0
+    ? ((1 - totalCode / totalTool) * 100).toFixed(1)
+    : "0";
+  console.log(
+    `| **Total** | **${kb(totalTool)}** | **${kb(totalCode)}** | **${totalPct}%** |`
+  );
+
+  console.log(`\nTokens saved: ~${Math.round((totalTool - totalCode) / 4).toLocaleString()}`);
+
+  // Write results file
+  const outPath = "tests/benchmark-results.json";
+  writeFileSync(
+    outPath,
+    JSON.stringify({ timestamp: new Date().toISOString(), results }, null, 2),
+  );
+  console.log(`\nResults written to ${outPath}`);
+}
+
+function kb(b: number): string {
+  if (b === 0) return "0B";
+  if (b < 1024) return `${b}B`;
+  if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)}KB`;
+  return `${(b / 1024 / 1024).toFixed(1)}MB`;
+}
+
+run().catch((err) => {
+  console.error("Benchmark failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `kubectl_code_mode` tool — runs a kubectl command, passes raw output as `DATA` variable to a user-provided script in a sandboxed child process, returns only the script's stdout to context
- Gated behind `ENABLE_CODE_MODE=true` — off by default, existing tools unchanged
- Supports 11 languages: JavaScript, TypeScript, Python, Shell, Ruby, Go, Rust, PHP, Perl, R, Elixir (auto-detects what's installed)
- Each response includes inline measurement: `[code-mode: 18.0KB → 6.2KB (65.5% reduction)]`
- Includes benchmark script (`tests/benchmark-code-mode.ts`) for before/after measurement against a real cluster

## Motivation

On clusters with many resources, tools like `kubectl_get` can return hundreds of KB of JSON. This consumes LLM context window quickly. Code mode lets the LLM write a processing script so only a compact summary enters context.

Inspired by [Cloudflare Code Mode](https://blog.cloudflare.com/code-mode-mcp/) and [claude-context-mode](https://github.com/mksglu/claude-context-mode)

## Benchmark Results

Compared against what existing tools (`kubectl_get`, `list_api_resources`) actually return — not raw kubectl JSON. Both sides use the exact same kubectl command.

| Test | Tool Response | Code-Mode Output | Reduction |
|---|---|---|---|
| List all pods (all namespaces) | 18.0KB | 6.2KB | 65.5% |
| List all deployments (all namespaces) | 8.6KB | 1.8KB | 78.8% |
| List all services (all namespaces) | 12.2KB | 4.0KB | 67.7% |
| List all events (all namespaces) | 136.4KB | 2.3KB | 98.3% |
| List all configmaps (all namespaces) | 27.3KB | 6.9KB | 74.6% |
| List nodes | 1.1KB | 417B | 63.2% |
| List API resources | 22.7KB | 154B | 99.3% |
| **Total** | **226.2KB** | **21.7KB** | **90.4%** |

## Usage

```bash
ENABLE_CODE_MODE=true node dist/index.js
```

The LLM sees one new tool:

```
kubectl_code_mode(args: "get pods -A -o json", code: "...", language?: "javascript")
```

## New files

| File | Purpose |
|---|---|
| `src/tools/kubectl-code-mode.ts` | Tool schema + handler |
| `src/utils/executor.ts` | PolyglotExecutor — sandboxed child process execution |
| `src/utils/runtime.ts` | Runtime detection (which languages are installed) |
| `src/index.ts` | Wired in, gated behind env var |
| `tests/benchmark-code-mode.ts` | Before/after benchmark script |

## Test plan

- [ ] `npm run build` compiles cleanly
- [ ] Existing tests pass (`npm test`)
- [ ] With `ENABLE_CODE_MODE=true`, `kubectl_code_mode` appears in tool list
- [ ] Without env var, no new tools exposed
- [ ] Run `npx tsx tests/benchmark-code-mode.ts` against a real cluster to verify savings