### PR TITLE
Add AgentRank score badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ https://github.com/user-attachments/assets/f25f8f4e-4d04-479b-9ae0-5dac452dd2ed
 
 <a href="https://glama.ai/mcp/servers/w71ieamqrt"><img width="380" height="200" src="https://glama.ai/mcp/servers/w71ieamqrt/badge" /></a>
 
+[![AgentRank](https://agentrank-ai.com/api/badge/tool/Flux159--mcp-server-kubernetes)](https://agentrank-ai.com/tool/Flux159--mcp-server-kubernetes/)
+
 ## Installation & Usage
 
 ### Prerequisites


### PR DESCRIPTION
Hi! Your tool ranks in the top 20 on [AgentRank](https://agentrank-ai.com/tool/Flux159--mcp-server-kubernetes/), a ranked index of MCP servers and agent tools scored daily from real GitHub signals. **mcp-server-kubernetes** currently scores **66.07/100**.

This PR adds a score badge to your README so visitors can see how the tool stacks up in the ecosystem:

[![AgentRank](https://agentrank-ai.com/api/badge/tool/Flux159--mcp-server-kubernetes)](https://agentrank-ai.com/tool/Flux159--mcp-server-kubernetes/)

Happy to adjust placement. No pressure to merge — just wanted to let you know you're ranking well.