### PR TITLE
Add kubectl_reconnect tool to fix stale API connections after EKS upgrades

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,10 @@ import {
   kubectlContext,
   kubectlContextSchema,
 } from "./tools/kubectl-context.js";
+import {
+  kubectlReconnect,
+  kubectlReconnectSchema,
+} from "./tools/kubectl-reconnect.js";
 import { kubectlGet, kubectlGetSchema } from "./tools/kubectl-get.js";
 import {
   kubectlDescribe,
@@ -88,6 +92,7 @@ const readonlyTools = [
   kubectlDescribeSchema,
   kubectlLogsSchema,
   kubectlContextSchema,
+  kubectlReconnectSchema,
   explainResourceSchema,
   listApiResourcesSchema,
   pingSchema,
@@ -121,6 +126,7 @@ const allTools = [
 
   // Kubernetes context management
   kubectlContextSchema,
+  kubectlReconnectSchema,
 
   // Special operations that aren't covered by simple kubectl commands
   explainResourceSchema,
@@ -218,6 +224,10 @@ server.setRequestHandler(
             context?: string;
           }
         );
+      }
+
+      if (name === "kubectl_reconnect") {
+        return await kubectlReconnect(k8sManager);
       }
 
       if (name === "kubectl_get") {

--- a/src/tools/kubectl-reconnect.ts
+++ b/src/tools/kubectl-reconnect.ts
@@ -6,7 +6,7 @@ export const kubectlReconnectSchema = {
   description:
     "Reconnect to the Kubernetes API server by recreating all API clients. Use this after cluster upgrades (e.g., EKS control plane upgrades that rotate ENIs/IPs) to force fresh DNS resolution and new TCP connections.",
   annotations: {
-    readOnlyHint: true,
+    readOnlyHint: false,
   },
   inputSchema: {
     type: "object",

--- a/src/tools/kubectl-reconnect.ts
+++ b/src/tools/kubectl-reconnect.ts
@@ -1,0 +1,43 @@
+import { KubernetesManager } from "../types.js";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+
+export const kubectlReconnectSchema = {
+  name: "kubectl_reconnect",
+  description:
+    "Reconnect to the Kubernetes API server by recreating all API clients. Use this after cluster upgrades (e.g., EKS control plane upgrades that rotate ENIs/IPs) to force fresh DNS resolution and new TCP connections.",
+  annotations: {
+    readOnlyHint: true,
+  },
+  inputSchema: {
+    type: "object",
+    properties: {},
+    required: [],
+  },
+} as const;
+
+export async function kubectlReconnect(k8sManager: KubernetesManager) {
+  try {
+    k8sManager.refreshApiClients();
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              success: true,
+              message:
+                "API clients refreshed. DNS will be re-resolved on the next request.",
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  } catch (error: any) {
+    throw new McpError(
+      ErrorCode.InternalError,
+      `Failed to reconnect: ${error.message}`
+    );
+  }
+}

--- a/src/utils/kubernetes-manager.ts
+++ b/src/utils/kubernetes-manager.ts
@@ -231,6 +231,12 @@ export class KubernetesManager {
    *
    * @param contextName
    */
+  public refreshApiClients(): void {
+    this.k8sApi = this.kc.makeApiClient(k8s.CoreV1Api);
+    this.k8sAppsApi = this.kc.makeApiClient(k8s.AppsV1Api);
+    this.k8sBatchApi = this.kc.makeApiClient(k8s.BatchV1Api);
+  }
+
   public setCurrentContext(contextName: string) {
     // Get all available contexts
     const contexts = this.kc.getContexts();

--- a/tests/kubectl-reconnect.unit.test.ts
+++ b/tests/kubectl-reconnect.unit.test.ts
@@ -1,0 +1,43 @@
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { kubectlReconnect } from "../src/tools/kubectl-reconnect.js";
+import { KubernetesManager } from "../src/utils/kubernetes-manager.js";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+
+describe("kubectl_reconnect tool", () => {
+  let mockK8sManager: Partial<KubernetesManager>;
+
+  beforeEach(() => {
+    mockK8sManager = {
+      refreshApiClients: vi.fn(),
+    };
+  });
+
+  test("should call refreshApiClients and return success response", async () => {
+    const result = await kubectlReconnect(
+      mockK8sManager as KubernetesManager
+    );
+
+    expect(mockK8sManager.refreshApiClients).toHaveBeenCalledOnce();
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+
+    const responseData = JSON.parse(result.content[0].text);
+    expect(responseData.success).toBe(true);
+    expect(responseData.message).toContain("DNS will be re-resolved");
+  });
+
+  test("should throw McpError when refreshApiClients throws", async () => {
+    vi.mocked(mockK8sManager.refreshApiClients!).mockImplementation(() => {
+      throw new Error("connection reset");
+    });
+
+    await expect(
+      kubectlReconnect(mockK8sManager as KubernetesManager)
+    ).rejects.toThrow(McpError);
+
+    await expect(
+      kubectlReconnect(mockK8sManager as KubernetesManager)
+    ).rejects.toThrow("Failed to reconnect: connection reset");
+  });
+});


### PR DESCRIPTION
## Problem

When an EKS cluster undergoes a control plane upgrade, AWS rotates the ENIs (Elastic Network Interfaces) attached to the API server. The IP addresses behind the API endpoint hostname change, but the `@kubernetes/client-node` API clients maintain persistent HTTP/HTTPS connections that have cached the old IPs. This causes all JavaScript client operations to fail until the MCP server process is restarted.

## Root Cause

In `KubernetesManager`, the three API clients (`k8sApi`, `k8sAppsApi`, `k8sBatchApi`) are created once in the constructor via `makeApiClient()`. The underlying Node.js HTTP agent pools TCP connections and caches the resolved IP. After ENI rotation, these stale connections point to IPs that no longer exist.

Note: `kubectl` subprocess-based operations are unaffected since each subprocess performs a fresh DNS lookup.

## Fix

- Added `refreshApiClients()` to `KubernetesManager` — recreates all three API client instances, which forces new DNS resolution and fresh TCP connections on the next request
- Added a new `kubectl_reconnect` MCP tool that calls `refreshApiClients()`

## Usage

After an EKS cluster upgrade (or any event that rotates control plane IPs), call the `kubectl_reconnect` tool to restore connectivity without restarting the MCP server process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)