### PR TITLE
fix: use constant-time comparison for auth token

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,4 +1,17 @@
+import { timingSafeEqual } from "crypto";
 import { Request, Response, NextFunction } from "express";
+
+/** Constant-time string comparison that prevents timing attacks (CWE-208). */
+function timingSafeCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    // Compare against itself to keep constant time, then return false
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
 
 /**
  * Authentication middleware for MCP HTTP transports.
@@ -37,7 +50,7 @@ export function createAuthMiddleware() {
       return;
     }
 
-    if (providedToken !== authToken) {
+    if (!timingSafeCompare(String(providedToken), authToken)) {
       res.status(403).json({
         jsonrpc: "2.0",
         error: {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -50,7 +50,20 @@ export function createAuthMiddleware() {
       return;
     }
 
-    if (!timingSafeCompare(String(providedToken), authToken)) {
+    // Reject array-valued headers (e.g. duplicate X-MCP-AUTH)
+    if (Array.isArray(providedToken)) {
+      res.status(401).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32001,
+          message: "Unauthorized: Only single X-MCP-AUTH header is allowed",
+        },
+        id: null,
+      });
+      return;
+    }
+
+    if (!timingSafeCompare(providedToken, authToken)) {
       res.status(403).json({
         jsonrpc: "2.0",
         error: {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,99 @@
+import { expect, test, describe, vi, beforeEach, afterEach } from "vitest";
+import { createAuthMiddleware } from "../src/utils/auth.js";
+import type { Request, Response, NextFunction } from "express";
+
+/** Helper to create a mock Express request with optional headers. */
+function mockReq(headers: Record<string, string | string[] | undefined> = {}): Request {
+  return { headers } as unknown as Request;
+}
+
+/** Helper to create a mock Express response with json/status spies. */
+function mockRes(): Response & { statusCode: number; body: unknown } {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(data: unknown) {
+      res.body = data;
+      return res;
+    },
+  };
+  return res as unknown as Response & { statusCode: number; body: unknown };
+}
+
+describe("createAuthMiddleware", () => {
+  const originalEnv = process.env.MCP_AUTH_TOKEN;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MCP_AUTH_TOKEN;
+    } else {
+      process.env.MCP_AUTH_TOKEN = originalEnv;
+    }
+  });
+
+  test("allows all requests when MCP_AUTH_TOKEN is not set", () => {
+    delete process.env.MCP_AUTH_TOKEN;
+    const middleware = createAuthMiddleware();
+    const next = vi.fn();
+    middleware(mockReq(), mockRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  test("returns 401 when X-MCP-AUTH header is missing", () => {
+    process.env.MCP_AUTH_TOKEN = "secret";
+    const middleware = createAuthMiddleware();
+    const res = mockRes();
+    const next = vi.fn();
+    middleware(mockReq(), res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect((res.body as any).error.code).toBe(-32001);
+  });
+
+  test("returns 401 when X-MCP-AUTH header is an array (duplicate headers)", () => {
+    process.env.MCP_AUTH_TOKEN = "secret";
+    const middleware = createAuthMiddleware();
+    const res = mockRes();
+    const next = vi.fn();
+    middleware(mockReq({ "x-mcp-auth": ["token1", "token2"] }), res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect((res.body as any).error.message).toContain("single");
+  });
+
+  test("returns 403 when token does not match", () => {
+    process.env.MCP_AUTH_TOKEN = "secret";
+    const middleware = createAuthMiddleware();
+    const res = mockRes();
+    const next = vi.fn();
+    middleware(mockReq({ "x-mcp-auth": "wrong-token" }), res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+  });
+
+  test("calls next() when token matches", () => {
+    process.env.MCP_AUTH_TOKEN = "secret";
+    const middleware = createAuthMiddleware();
+    const next = vi.fn();
+    middleware(mockReq({ "x-mcp-auth": "secret" }), mockRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  test("uses constant-time comparison (no early return on first mismatch)", () => {
+    process.env.MCP_AUTH_TOKEN = "correct-token";
+    const middleware = createAuthMiddleware();
+
+    // Both wrong tokens should take similar time (not measurably different)
+    // This is a basic structural test — true timing tests need statistical analysis
+    const res1 = mockRes();
+    const res2 = mockRes();
+    middleware(mockReq({ "x-mcp-auth": "Xorrect-token" }), res1, vi.fn()); // first char wrong
+    middleware(mockReq({ "x-mcp-auth": "correct-tokeX" }), res2, vi.fn()); // last char wrong
+    expect(res1.statusCode).toBe(403);
+    expect(res2.statusCode).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace direct string comparison (`!==`) with `crypto.timingSafeEqual()` in the auth middleware to prevent timing-based side-channel attacks ([CWE-208](https://cwe.mitre.org/data/definitions/208.html))
- Add a `timingSafeCompare` helper that handles variable-length strings safely (compares against itself on length mismatch to avoid leaking length information)
- Add `import { timingSafeEqual } from 'crypto'`

Fixes #292

## Details

The `providedToken !== authToken` comparison in `src/utils/auth.ts` (line 40) exits early on the first mismatched byte. An attacker observing response latency can incrementally guess the token character by character.

`crypto.timingSafeEqual()` always compares all bytes in constant time, eliminating the timing oracle.

## Test plan

- [ ] Verify auth middleware still allows requests with correct `X-MCP-AUTH` header
- [ ] Verify auth middleware rejects requests with incorrect token
- [ ] Verify server works without `MCP_AUTH_TOKEN` configured (no-auth mode)
---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*