### PR TITLE
Fix argument injection in port_forward tool

### DIFF
--- a/src/tools/port_forward.ts
+++ b/src/tools/port_forward.ts
@@ -3,12 +3,11 @@ import { z } from "zod";
 import { KubernetesManager } from "../utils/kubernetes-manager.js";
 
 // Use spawn instead of exec because port-forward is a long-running process
-async function executeKubectlCommandAsync(
-  command: string
+async function executePortForward(
+  args: string[]
 ): Promise<{ success: boolean; message: string; pid: number }> {
   return new Promise((resolve, reject) => {
-    const [cmd, ...args] = command.split(" ");
-    const process = spawn(cmd, args);
+    const process = spawn("kubectl", args);
 
     let output = "";
     let errorOutput = "";
@@ -82,14 +81,15 @@ export async function startPortForward(
     namespace?: string;
   }
 ): Promise<{ content: { success: boolean; message: string }[] }> {
-  let command = `kubectl port-forward`;
+  const args = ["port-forward"];
   if (input.namespace) {
-    command += ` -n ${input.namespace}`;
+    args.push("-n", input.namespace);
   }
-  command += ` ${input.resourceType}/${input.resourceName} ${input.localPort}:${input.targetPort}`;
+  args.push(`${input.resourceType}/${input.resourceName}`);
+  args.push(`${input.localPort}:${input.targetPort}`);
 
   try {
-    const result = await executeKubectlCommandAsync(command);
+    const result = await executePortForward(args);
     // Track the port-forward process
     k8sManager.trackPortForward({
       id: `${input.resourceType}-${input.resourceName}-${input.localPort}`,


### PR DESCRIPTION
## Summary

- Replace string-based command construction with array-based argument passing in `startPortForward`, preventing argument injection via user-controlled fields (`namespace`, `resourceType`, `resourceName`)
- The previous approach concatenated inputs into a command string and split on spaces, allowing crafted values to inject additional kubectl flags
- Now uses a `string[]` args array passed directly to `spawn("kubectl", args)`, matching the safe pattern used by other tools

## Test plan

- [ ] Verify port-forward still works with namespace specified
- [ ] Verify port-forward works without namespace (default behavior)
- [ ] Confirm inputs containing spaces or dashes are treated as single arguments and don't inject flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)