### PR TITLE
Fix port_forward tool returning non-spec MCP content

### DIFF
--- a/src/models/response-schemas.ts
+++ b/src/models/response-schemas.ts
@@ -83,12 +83,7 @@ export const GetJobLogsResponseSchema = z.object({
 });
 
 export const PortForwardResponseSchema = z.object({
-  content: z.array(
-    z.object({
-      success: z.boolean(),
-      message: z.string(),
-    })
-  ),
+  content: z.array(ToolResponseContent),
 });
 
 export const ScaleDeploymentResponseSchema = z.object({

--- a/src/tools/port_forward.ts
+++ b/src/tools/port_forward.ts
@@ -80,7 +80,7 @@ export async function startPortForward(
     targetPort: number;
     namespace?: string;
   }
-): Promise<{ content: { success: boolean; message: string }[] }> {
+): Promise<{ content: { type: "text"; text: string }[] }> {
   const args = ["port-forward"];
   if (input.namespace) {
     args.push("-n", input.namespace);
@@ -111,7 +111,15 @@ export async function startPortForward(
       ports: [{ local: input.localPort, remote: input.targetPort }],
     });
     return {
-      content: [{ success: result.success, message: result.message }],
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            success: result.success,
+            message: result.message,
+          }),
+        },
+      ],
     };
   } catch (error: any) {
     throw new Error(`Failed to execute port-forward: ${error.message}`);
@@ -138,7 +146,7 @@ export async function stopPortForward(
   input: {
     id: string;
   }
-): Promise<{ content: { success: boolean; message: string }[] }> {
+): Promise<{ content: { type: "text"; text: string }[] }> {
   const portForward = k8sManager.getPortForward(input.id);
   if (!portForward) {
     throw new Error(`Port-forward with id ${input.id} not found`);
@@ -149,7 +157,13 @@ export async function stopPortForward(
     k8sManager.removePortForward(input.id);
     return {
       content: [
-        { success: true, message: "port-forward stopped successfully" },
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            success: true,
+            message: "port-forward stopped successfully",
+          }),
+        },
       ],
     };
   } catch (error: any) {


### PR DESCRIPTION
## Summary

`startPortForward` and `stopPortForward` return content items shaped as `{success, message}`, which violates the MCP content spec — content items must be `{type: "text", text: string}` (see `ToolResponseContent` in `src/models/response-schemas.ts`).

In practice, MCP clients reject the response with a zod `invalid_union` error ("expected text"), but `kubectl` has already bound the local port by the time the response is validated. Retries then leak `kubectl port-forward` processes and report `address already in use`. The same goes for `stop_port_forward` — the underlying process is killed, but the client sees an error and the user thinks the call failed.

## Changes

- `src/tools/port_forward.ts`:
  - Wrap both `startPortForward` and `stopPortForward` responses in `{type: "text" as const, text: JSON.stringify(...)}`, matching the pattern already used by `kubectl-scale`, `kubectl-get`, `helm-operations`, and `node-management`.
  - Update the function return-type signatures from `{ content: { success: boolean; message: string }[] }` to `{ content: { type: "text"; text: string }[] }`.
- `src/models/response-schemas.ts`:
  - Replace the bespoke `PortForwardResponseSchema` content shape with the shared `ToolResponseContent`, so client-side validation matches the new wire shape.

No behavior change beyond the response shape — the same `{success, message}` payload is now serialized as the `text` field of a text content item, consistent with every other tool in this server.

## Test plan

- [x] `tsc` build clean (verified via `docker build --target dependencies`).
- [ ] Manual: invoke `port_forward` from an MCP client and confirm no `invalid_union` validation error and no leaked kubectl processes on subsequent calls.
- [ ] Manual: invoke `stop_port_forward` and confirm a clean response.