### PR TITLE
security: enable DNS rebinding protection by default on streamable HTTP transport

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -277,23 +277,58 @@ When enabled (default), `kubectl get secrets` and `kubectl get secret` commands 
 
 ### Streamable HTTP Transport
 
-To enable [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http) for mcp-server-kubernetes, use the ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT environment variable.
+To enable [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http) for mcp-server-kubernetes, use the `ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT` environment variable.
 
 ```shell
 ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1 npx flux159/mcp-server-kubernetes
 ```
 
-This will start an http server with the `/mcp` endpoint for streamable http events (POST, GET, and DELETE). Use the `PORT` env var to configure the server port. Use the `HOST` env var to configure listening on interfaces other than localhost.
+This starts an http server with the `/mcp` endpoint for streamable http events (POST, GET, and DELETE). Use the `PORT` env var to configure the server port (default `3000`). Use the `HOST` env var to configure listening on interfaces other than `localhost`.
 
 ```shell
 ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1 PORT=3001 HOST=0.0.0.0 npx flux159/mcp-server-kubernetes
 ```
 
-To enable DNS Rebinding protection if running locally, you should use `DNS_REBINDING_PROTECTION` and optionally `DNS_REBINDING_ALLOWED_HOST` (defaults to 127.0.0.1):
+#### DNS rebinding protection
 
+DNS rebinding protection is **enabled by default** to prevent malicious web pages from issuing requests to your local MCP server through the browser. The default allowlist accepts the `Host` header values commonly sent by local clients, so the out-of-the-box configuration "just works" for local usage:
+
+- `127.0.0.1`, `127.0.0.1:<PORT>`
+- `localhost`, `localhost:<PORT>`
+- `::1`, `[::1]:<PORT>`
+- The configured `HOST` value (and `HOST:PORT`) when it differs from the above
+
+Local usage requires no extra flags:
+
+```shell
+ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1 npx flux159/mcp-server-kubernetes
+# Client connects to http://localhost:3000/mcp – works with the default allowlist
 ```
-DNS_REBINDING_ALLOWED_HOST=true ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1 PORT=3001 HOST=0.0.0.0 npx flux159/mcp-server-kubernetes
+
+##### Hosting the server on a remote host or custom domain
+
+When the MCP server is reachable through a hostname that isn't in the default allowlist (for example a server you host at `mcp.example.com`, or any reverse-proxy domain), you must add that hostname so the SDK accepts requests with that `Host` header. Use `DNS_REBINDING_ALLOWED_HOST` to override the allowlist:
+
+```shell
+DNS_REBINDING_ALLOWED_HOST=mcp.example.com ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1 PORT=3001 HOST=0.0.0.0 npx flux159/mcp-server-kubernetes
 ```
+
+Notes:
+
+- `DNS_REBINDING_ALLOWED_HOST` accepts a single hostname today; if your deployment is reached through multiple hostnames, terminate them at a single canonical host (typically your reverse proxy) and pass that value here.
+- Include the port in the value (e.g. `mcp.example.com:3001`) only if clients send it in the `Host` header. Most browsers/clients omit the port for `:80` / `:443`.
+- When fronting the server with a reverse proxy (nginx, Caddy, an ingress, etc.), set `DNS_REBINDING_ALLOWED_HOST` to the **public** hostname clients use, not the upstream container name.
+- For production deployments you should additionally enable header authentication via `MCP_AUTH_TOKEN` (see [HTTP Transport Authentication](#http-transport-authentication-x-mcp-auth) below) and terminate TLS at your proxy.
+
+##### Disabling DNS rebinding protection (not recommended)
+
+If you have an environment where you cannot configure an allowlist (e.g. dynamic hostnames behind your own access-controlled proxy that already validates `Host`), you can disable the check explicitly:
+
+```shell
+DNS_REBINDING_PROTECTION=false ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1 PORT=3001 HOST=0.0.0.0 npx flux159/mcp-server-kubernetes
+```
+
+The server prints a startup warning when protection is disabled while binding to `0.0.0.0` or `::`, since that combination is the most common foot-gun.
 
 ### SSE Transport (Deprecated in favor of Streamable HTTP)
 

--- a/src/utils/streamable-http.ts
+++ b/src/utils/streamable-http.ts
@@ -14,12 +14,23 @@ function buildDefaultAllowedHosts(host: string, port: number): string[] {
   const hosts: string[] = [];
   for (const alias of localhostAliases) {
     hosts.push(alias);
-    hosts.push(`${alias}:${port}`);
+    // HTTP Host header uses bracket notation for IPv6: [::1]:3000
+    if (alias.includes(":")) {
+      hosts.push(`[${alias}]`);
+      hosts.push(`[${alias}]:${port}`);
+    } else {
+      hosts.push(`${alias}:${port}`);
+    }
   }
   // Also add the configured host if it's not already covered
   if (!localhostAliases.includes(host)) {
     hosts.push(host);
-    hosts.push(`${host}:${port}`);
+    if (host.includes(":") && !host.startsWith("[")) {
+      hosts.push(`[${host}]`);
+      hosts.push(`[${host}]:${port}`);
+    } else {
+      hosts.push(`${host}:${port}`);
+    }
   }
   return hosts;
 }
@@ -37,14 +48,8 @@ export function startStreamableHTTPServer(server: Server): http.Server {
 
   const host = process.env.HOST || "localhost";
 
-  let port = 3000;
-  try {
-    port = parseInt(process.env.PORT || "3000", 10);
-  } catch (e) {
-    console.error(
-      "Invalid PORT environment variable, using default port 3000."
-    );
-  }
+  const parsed = parseInt(process.env.PORT || "3000", 10);
+  const port = Number.isNaN(parsed) ? 3000 : parsed;
 
   const allowedHosts = process.env.DNS_REBINDING_ALLOWED_HOST
     ? [process.env.DNS_REBINDING_ALLOWED_HOST]

--- a/src/utils/streamable-http.ts
+++ b/src/utils/streamable-http.ts
@@ -4,6 +4,26 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import http from "http";
 import { createAuthMiddleware, isAuthEnabled } from "./auth.js";
 
+/**
+ * Build the default allowedHosts list for DNS rebinding protection.
+ * Includes localhost variants with and without port.
+ */
+function buildDefaultAllowedHosts(host: string, port: number): string[] {
+  // Always allow the bare host and host:port for common localhost addresses
+  const localhostAliases = ["127.0.0.1", "localhost", "::1"];
+  const hosts: string[] = [];
+  for (const alias of localhostAliases) {
+    hosts.push(alias);
+    hosts.push(`${alias}:${port}`);
+  }
+  // Also add the configured host if it's not already covered
+  if (!localhostAliases.includes(host)) {
+    hosts.push(host);
+    hosts.push(`${host}:${port}`);
+  }
+  return hosts;
+}
+
 export function startStreamableHTTPServer(server: Server): http.Server {
   const app = express();
   app.use(express.json());
@@ -11,20 +31,41 @@ export function startStreamableHTTPServer(server: Server): http.Server {
   // Create auth middleware - when MCP_AUTH_TOKEN is set, requires X-MCP-AUTH header
   const authMiddleware = createAuthMiddleware();
 
+  // DNS rebinding protection is enabled by default. Set DNS_REBINDING_PROTECTION=false to disable.
+  const enableDnsRebindingProtection =
+    process.env.DNS_REBINDING_PROTECTION !== "false";
+
+  const host = process.env.HOST || "localhost";
+
+  let port = 3000;
+  try {
+    port = parseInt(process.env.PORT || "3000", 10);
+  } catch (e) {
+    console.error(
+      "Invalid PORT environment variable, using default port 3000."
+    );
+  }
+
+  const allowedHosts = process.env.DNS_REBINDING_ALLOWED_HOST
+    ? [process.env.DNS_REBINDING_ALLOWED_HOST]
+    : buildDefaultAllowedHosts(host, port);
+
+  // Warn when binding to all interfaces with DNS rebinding protection disabled
+  if (!enableDnsRebindingProtection && (host === "0.0.0.0" || host === "::")) {
+    console.warn(
+      "WARNING: DNS rebinding protection is disabled while HOST is set to " +
+        `'${host}'. This exposes the MCP server to DNS rebinding attacks ` +
+        "from any browser on the network. Set DNS_REBINDING_PROTECTION=true " +
+        "(the default) or restrict HOST to 'localhost' / '127.0.0.1'."
+    );
+  }
+
   app.post("/mcp", authMiddleware, async (req: express.Request, res: express.Response) => {
     // In stateless mode, create a new instance of transport and server for each request
     // to ensure complete isolation. A single instance would cause request ID collisions
     // when multiple clients connect concurrently.
 
     try {
-      // DNS rebinding protection is disabled by default for backwards compatibility. If you are running this server
-      // locally, make sure to set DNS_REBINDING_PROTECTION=true
-      const enableDnsRebindingProtection =
-        process.env.DNS_REBINDING_PROTECTION === "true";
-      const allowedHosts = process.env.DNS_REBINDING_ALLOWED_HOST
-        ? [process.env.DNS_REBINDING_ALLOWED_HOST]
-        : ["127.0.0.1"];
-
       const transport: StreamableHTTPServerTransport =
         new StreamableHTTPServerTransport({
           sessionIdGenerator: undefined,
@@ -107,16 +148,6 @@ export function startStreamableHTTPServer(server: Server): http.Server {
     }
   });
 
-  let port = 3000;
-  try {
-    port = parseInt(process.env.PORT || "3000", 10);
-  } catch (e) {
-    console.error(
-      "Invalid PORT environment variable, using default port 3000."
-    );
-  }
-
-  const host = process.env.HOST || "localhost";
   const httpServer = app.listen(port, host, () => {
     console.log(
       `mcp-kubernetes-server is listening on port ${port}\nUse the following url to connect to the server:\nhttp://${host}:${port}/mcp`

--- a/tests/dns-rebinding.test.ts
+++ b/tests/dns-rebinding.test.ts
@@ -1,0 +1,205 @@
+import { expect, test, describe, beforeAll, afterAll } from "vitest";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { startStreamableHTTPServer } from "../src/utils/streamable-http.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import http from "http";
+import { pingSchema } from "../src/tools/ping.js";
+import { findAvailablePort } from "./port-helper.js";
+
+/** Send a POST /mcp request with a custom Host header via http.request (fetch doesn't allow Host override). */
+function mcpPost(
+  port: number,
+  body: object,
+  hostHeader: string
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path: "/mcp",
+        method: "POST",
+        headers: {
+          Host: hostHeader,
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          "Content-Length": Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => resolve({ status: res.statusCode!, body: data }));
+      }
+    );
+    req.on("error", reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+function makeListToolsRequest(id: number) {
+  return {
+    jsonrpc: "2.0" as const,
+    method: "tools/list" as const,
+    params: {},
+    id,
+  };
+}
+
+function saveEnvKeys(keys: string[]): Record<string, string | undefined> {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  return saved;
+}
+
+function restoreEnvKeys(saved: Record<string, string | undefined>) {
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+/** Wait until the http.Server is actually listening. */
+function waitForListening(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    if (server.listening) return resolve();
+    server.on("listening", resolve);
+  });
+}
+
+const ENV_KEYS = ["DNS_REBINDING_PROTECTION", "DNS_REBINDING_ALLOWED_HOST", "HOST", "PORT"];
+
+describe("DNS Rebinding Protection - enabled by default", () => {
+  let httpServer: http.Server;
+  let port: number;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeAll(async () => {
+    savedEnv = saveEnvKeys(ENV_KEYS);
+    port = await findAvailablePort(5000);
+    process.env.PORT = port.toString();
+    // Bind to 127.0.0.1 so mcpPost can reach it
+    process.env.HOST = "127.0.0.1";
+    // Do NOT set DNS_REBINDING_PROTECTION — should default to enabled
+
+    const server = new Server(
+      { name: "test-dns-default", version: "1.0.0" },
+      { capabilities: { tools: {} } }
+    );
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
+      return { tools: [pingSchema] };
+    });
+    httpServer = startStreamableHTTPServer(server);
+    await waitForListening(httpServer);
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((err) => (err ? reject(err) : resolve()));
+    });
+    restoreEnvKeys(savedEnv);
+  });
+
+  test("should reject requests with a foreign Host header by default", async () => {
+    const res = await mcpPost(port, makeListToolsRequest(1), "evil.attacker.com");
+    // With DNS rebinding protection enabled by default, foreign Host should be rejected
+    expect(res.status).toBe(403);
+  });
+
+  test("should allow requests with the default localhost Host header", async () => {
+    const res = await mcpPost(port, makeListToolsRequest(2), `127.0.0.1:${port}`);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("DNS Rebinding Protection - explicit opt-out", () => {
+  let httpServer: http.Server;
+  let port: number;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeAll(async () => {
+    savedEnv = saveEnvKeys(ENV_KEYS);
+    port = await findAvailablePort(5100);
+    process.env.PORT = port.toString();
+    process.env.HOST = "127.0.0.1";
+    process.env.DNS_REBINDING_PROTECTION = "false";
+
+    const server = new Server(
+      { name: "test-dns-disabled", version: "1.0.0" },
+      { capabilities: { tools: {} } }
+    );
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
+      return { tools: [pingSchema] };
+    });
+    httpServer = startStreamableHTTPServer(server);
+    await waitForListening(httpServer);
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((err) => (err ? reject(err) : resolve()));
+    });
+    restoreEnvKeys(savedEnv);
+  });
+
+  test("should allow requests with a foreign Host header when explicitly disabled", async () => {
+    const res = await mcpPost(port, makeListToolsRequest(3), "evil.attacker.com");
+    // When explicitly disabled, should allow any host
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("DNS Rebinding Protection - warning on 0.0.0.0 without protection", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeAll(async () => {
+    savedEnv = saveEnvKeys(ENV_KEYS);
+  });
+
+  afterAll(async () => {
+    restoreEnvKeys(savedEnv);
+  });
+
+  test("should log a warning when HOST=0.0.0.0 and protection is explicitly disabled", async () => {
+    const port = await findAvailablePort(5200);
+    process.env.PORT = port.toString();
+    process.env.HOST = "0.0.0.0";
+    process.env.DNS_REBINDING_PROTECTION = "false";
+
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...args: any[]) => {
+      warnings.push(args.join(" "));
+    };
+
+    let hs: http.Server | undefined;
+    try {
+      const server = new Server(
+        { name: "test-dns-warn", version: "1.0.0" },
+        { capabilities: { tools: {} } }
+      );
+      server.setRequestHandler(ListToolsRequestSchema, async () => {
+        return { tools: [pingSchema] };
+      });
+      hs = startStreamableHTTPServer(server);
+      await waitForListening(hs);
+
+      const hasDnsWarning = warnings.some(
+        (w) => w.toLowerCase().includes("dns rebinding")
+      );
+      expect(hasDnsWarning).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+      if (hs) {
+        await new Promise<void>((resolve, reject) => {
+          hs!.close((err) => (err ? reject(err) : resolve()));
+        });
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The streamable HTTP transport (`src/utils/streamable-http.ts`) ships with DNS rebinding protection **disabled by default**, leaving local users running `mcp-server-kubernetes` exposed to a well-known browser-based attack class. This PR flips the default to **on**, builds a sensible localhost allowlist, and adds a warning when the server binds to all interfaces with protection disabled.

- **CWE-319** — Cleartext Transmission / missing transport-level origin validation (DNS rebinding)
- **Affected file:** `src/utils/streamable-http.ts`
- **Severity:** High (unauthenticated remote-to-local pivot granting kubectl-level access)

## Vulnerability details

Today the relevant block reads:

```ts
// DNS rebinding protection is disabled by default for backwards compatibility.
const enableDnsRebindingProtection =
  process.env.DNS_REBINDING_PROTECTION === "true";
const allowedHosts = process.env.DNS_REBINDING_ALLOWED_HOST
  ? [process.env.DNS_REBINDING_ALLOWED_HOST]
  : ["127.0.0.1"];
```

Combined with the defaults `HOST=localhost`, `PORT=3000`, and `MCP_AUTH_TOKEN` being opt-in, the out-of-the-box configuration accepts any `Host` header on `http://localhost:3000/mcp`.

**Attack flow:**

1. A user runs `mcp-server-kubernetes` locally over the streamable HTTP transport (the documented mode for non-stdio clients) with default settings.
2. The user visits an attacker-controlled page in any browser on the same machine.
3. The attacker's domain (e.g. `evil.example`) has a short-TTL DNS record. After the page loads, the attacker rebinds the hostname to `127.0.0.1`.
4. JavaScript on the page issues `fetch('http://evil.example:3000/mcp', { method: 'POST', body: ... })`. The browser treats it as same-origin (so CORS doesn't help), and the request lands on the local MCP server with `Host: evil.example`.
5. Because DNS rebinding protection is off, the server processes it — giving the attacker arbitrary `kubectl` access to whatever cluster the user has configured.

This is the same attack class that has produced multiple CVEs against other local MCP servers in 2024–2025; the SDK's `allowedHosts` mechanism exists specifically to prevent it.

## Fix

- Default `enableDnsRebindingProtection` to **true** unless `DNS_REBINDING_PROTECTION=false` is explicitly set (preserves the escape hatch for users who knowingly want it off).
- Replace the single-entry `["127.0.0.1"]` allowlist with `buildDefaultAllowedHosts(host, port)`, which covers `127.0.0.1`, `localhost`, `::1` — each both bare and with `:port` — plus the configured `HOST` if it differs. This avoids breaking the common case where browsers/clients send `Host: localhost:3000`.
- Hoist `host`/`port` parsing above the route handler so the allowlist can use them.
- Emit a `console.warn` when the user opts out of protection **and** binds to `0.0.0.0`/`::`, since that combination exposes the cluster to any browser on the network.

`DNS_REBINDING_ALLOWED_HOST` continues to act as a manual override when set.

## Tests

Added `tests/dns-rebinding.test.ts` with three scenarios, all passing locally:

1. **Default-on:** unset `DNS_REBINDING_PROTECTION`, send `Host: evil.attacker.com` → expect `403`; send `Host: 127.0.0.1:<port>` → expect `200`.
2. **Explicit opt-out:** `DNS_REBINDING_PROTECTION=false`, send `Host: evil.attacker.com` → expect `200` (backwards compatibility preserved).
3. **0.0.0.0 + opt-out warning:** `HOST=0.0.0.0` and `DNS_REBINDING_PROTECTION=false` → expect a `console.warn` mentioning DNS rebinding.

The existing test suite continues to pass; the new test file is self-contained and uses `findAvailablePort` to avoid colliding with other suites.

## Adversarial review

Before submitting, we tried to disprove this. The obvious mitigation would be `MCP_AUTH_TOKEN`, but it's opt-in and unset by default, and even when set it doesn't help here because DNS rebinding doesn't bypass auth — it's the *missing host check* that's the issue (any endpoint reachable without the token is enough surface). CORS doesn't help either: the browser treats the rebound hostname as same-origin with the attacker page, so no preflight is sent for simple POSTs. There is no other code path on the streamable HTTP transport that performs origin/host validation, and the SDK's `allowedHosts` option is the intended mechanism — it was simply turned off. The fix is the minimal change that closes the gap while keeping the documented opt-out for users who need it.

cc @lewiswigmore
