### PR TITLE
fix: prevent argument injection in port_forward tool (CWE-88)

### DIFF
--- a/src/tools/port_forward.ts
+++ b/src/tools/port_forward.ts
@@ -3,12 +3,11 @@ import { z } from "zod";
 import { KubernetesManager } from "../utils/kubernetes-manager.js";
 
 // Use spawn instead of exec because port-forward is a long-running process
-async function executeKubectlCommandAsync(
-  command: string
+async function executeKubectlPortForward(
+  args: string[]
 ): Promise<{ success: boolean; message: string; pid: number }> {
   return new Promise((resolve, reject) => {
-    const [cmd, ...args] = command.split(" ");
-    const process = spawn(cmd, args);
+    const process = spawn("kubectl", args);
 
     let output = "";
     let errorOutput = "";
@@ -82,14 +81,21 @@ export async function startPortForward(
     namespace?: string;
   }
 ): Promise<{ content: { success: boolean; message: string }[] }> {
-  let command = `kubectl port-forward`;
+  // Build argument array directly to prevent argument injection via
+  // string concatenation + split. Each user-controlled value is a
+  // single element in the array, so spaces in input cannot create
+  // additional arguments.
+  const args: string[] = ["port-forward"];
   if (input.namespace) {
-    command += ` -n ${input.namespace}`;
+    args.push("-n", input.namespace);
   }
-  command += ` ${input.resourceType}/${input.resourceName} ${input.localPort}:${input.targetPort}`;
+  args.push(
+    `${input.resourceType}/${input.resourceName}`,
+    `${input.localPort}:${input.targetPort}`
+  );
 
   try {
-    const result = await executeKubectlCommandAsync(command);
+    const result = await executeKubectlPortForward(args);
     // Track the port-forward process
     k8sManager.trackPortForward({
       id: `${input.resourceType}-${input.resourceName}-${input.localPort}`,

--- a/tests/port_forward_injection.test.ts
+++ b/tests/port_forward_injection.test.ts
@@ -1,0 +1,188 @@
+import { expect, test, describe, vi, beforeEach, afterEach } from "vitest";
+import * as child_process from "child_process";
+import { EventEmitter } from "events";
+
+// We'll test that executeKubectlPortForward (the refactored function) passes
+// arguments as discrete array elements to spawn, so user input containing
+// spaces does NOT split into extra arguments.
+
+// Mock spawn to capture its invocations
+vi.mock("child_process", async () => {
+  const actual = await vi.importActual<typeof child_process>("child_process");
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+// Import after mocking
+import { startPortForward } from "../src/tools/port_forward.js";
+
+function createMockProcess() {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.pid = 12345;
+  return proc;
+}
+
+function createMockK8sManager() {
+  return {
+    trackPortForward: vi.fn(),
+    getPortForward: vi.fn(),
+    removePortForward: vi.fn(),
+  } as any;
+}
+
+describe("port_forward argument injection prevention", () => {
+  let spawnMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    spawnMock = vi.mocked(child_process.spawn);
+    spawnMock.mockReset();
+  });
+
+  test("resourceName with spaces should be passed as a single argument, not split", async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+
+    const k8sManager = createMockK8sManager();
+    const maliciousName = "myresource --kubeconfig /tmp/evil";
+
+    const promise = startPortForward(k8sManager, {
+      resourceType: "pod",
+      resourceName: maliciousName,
+      localPort: 8080,
+      targetPort: 80,
+    });
+
+    // Simulate successful forwarding
+    setTimeout(() => {
+      proc.stdout.emit("data", "Forwarding from 127.0.0.1:8080 -> 80");
+    }, 10);
+
+    await promise;
+
+    // Verify spawn was called
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    const [cmd, args] = spawnMock.mock.calls[0];
+    expect(cmd).toBe("kubectl");
+
+    // The resource argument should be a single element containing the slash
+    // and the full (malicious) name — NOT split on spaces
+    const resourceArg = args.find((a: string) =>
+      a.startsWith("pod/")
+    );
+    expect(resourceArg).toBe(`pod/${maliciousName}`);
+
+    // There must NOT be a "--kubeconfig" argument injected
+    expect(args).not.toContain("--kubeconfig");
+    expect(args).not.toContain("/tmp/evil");
+  });
+
+  test("namespace with spaces should be passed as a single argument, not split", async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+
+    const k8sManager = createMockK8sManager();
+    const maliciousNamespace = "default --kubeconfig /tmp/evil";
+
+    const promise = startPortForward(k8sManager, {
+      resourceType: "pod",
+      resourceName: "nginx",
+      localPort: 8080,
+      targetPort: 80,
+      namespace: maliciousNamespace,
+    });
+
+    setTimeout(() => {
+      proc.stdout.emit("data", "Forwarding from 127.0.0.1:8080 -> 80");
+    }, 10);
+
+    await promise;
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    const [cmd, args] = spawnMock.mock.calls[0];
+    expect(cmd).toBe("kubectl");
+
+    // The namespace should be passed as a single arg after -n
+    const nIndex = args.indexOf("-n");
+    expect(nIndex).toBeGreaterThanOrEqual(0);
+    expect(args[nIndex + 1]).toBe(maliciousNamespace);
+
+    // There must NOT be injected arguments
+    expect(args).not.toContain("--kubeconfig");
+    expect(args).not.toContain("/tmp/evil");
+  });
+
+  test("resourceType with spaces should be passed as a single argument, not split", async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+
+    const k8sManager = createMockK8sManager();
+    const maliciousType = "pod --kubeconfig /tmp/evil";
+
+    const promise = startPortForward(k8sManager, {
+      resourceType: maliciousType,
+      resourceName: "nginx",
+      localPort: 8080,
+      targetPort: 80,
+    });
+
+    setTimeout(() => {
+      proc.stdout.emit("data", "Forwarding from 127.0.0.1:8080 -> 80");
+    }, 10);
+
+    await promise;
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    const [cmd, args] = spawnMock.mock.calls[0];
+    expect(cmd).toBe("kubectl");
+
+    // The resource arg should contain the malicious type unsplit
+    const resourceArg = args.find((a: string) =>
+      a.includes("/nginx")
+    );
+    expect(resourceArg).toBe(`${maliciousType}/nginx`);
+
+    // Injected flags must not be present as separate args
+    expect(args).not.toContain("--kubeconfig");
+    expect(args).not.toContain("/tmp/evil");
+  });
+
+  test("normal input should produce correct arguments", async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+
+    const k8sManager = createMockK8sManager();
+
+    const promise = startPortForward(k8sManager, {
+      resourceType: "pod",
+      resourceName: "nginx",
+      localPort: 8080,
+      targetPort: 80,
+      namespace: "production",
+    });
+
+    setTimeout(() => {
+      proc.stdout.emit("data", "Forwarding from 127.0.0.1:8080 -> 80");
+    }, 10);
+
+    await promise;
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    const [cmd, args] = spawnMock.mock.calls[0];
+    expect(cmd).toBe("kubectl");
+    expect(args).toEqual([
+      "port-forward",
+      "-n",
+      "production",
+      "pod/nginx",
+      "8080:80",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes an argument injection vulnerability (CWE-88) in the `port_forward` MCP tool. User-controlled `namespace`, `resourceType`, and `resourceName` values are concatenated into a kubectl command string, then split on spaces and passed to `spawn()`. Because the split happens after concatenation, a value containing spaces injects additional arguments to `kubectl`.

**Affected file:** `src/tools/port_forward.ts` (function `startPortForward` → `executeKubectlCommandAsync`)

### Data flow

1. MCP tool input → `startPortForward({ namespace, resourceType, resourceName, ... })`
2. String built: `` `kubectl port-forward -n ${namespace} ${resourceType}/${resourceName} ${localPort}:${targetPort}` ``
3. `executeKubectlCommandAsync` does `command.split(" ")` and passes the result to `spawn(cmd, args)`
4. A malicious `namespace` like `default --kubeconfig=/tmp/evil` becomes two separate kubectl flags

### Why this matters

`spawn()` without `shell: true` does prevent classic shell-metacharacter RCE — so this isn't a shell injection. But it does **not** prevent argument injection, because the splitting happens in JS before `spawn` is called. An attacker who can supply tool inputs can:

- Inject `--address=0.0.0.0` to bind the port-forward to all interfaces, exposing internal cluster services on the network (default is loopback only).
- Inject `--kubeconfig=/path/to/attacker.yaml` to redirect kubectl at an attacker-controlled cluster/credentials.
- Inject other kubectl flags that change behavior.

In an MCP context, tool inputs frequently originate from an LLM processing untrusted data, so prompt-injection-driven exploitation is realistic.

## Fix

Build an explicit `args` array and pass it directly to `spawn("kubectl", args)`. Each user-controlled value occupies exactly one array element, so spaces in input cannot create additional arguments. This is the standard, idiomatic way to call `spawn` safely.

The change is minimal and surgical — only the one call site is touched, and the public signature of `startPortForward` is unchanged.

```typescript
const args: string[] = ["port-forward"];
if (input.namespace) {
  args.push("-n", input.namespace);
}
args.push(
  `${input.resourceType}/${input.resourceName}`,
  `${input.localPort}:${input.targetPort}`
);
// ...
spawn("kubectl", args);
```

## Tests

Added `tests/port_forward_injection.test.ts` with four cases that mock `child_process.spawn` and assert the exact args array passed:

1. Malicious `resourceName` containing `--kubeconfig /tmp/evil` is kept as one element; injected flags are not present as separate args.
2. Malicious `namespace` containing injected flags is preserved as a single arg after `-n`.
3. Malicious `resourceType` is preserved as one element.
4. Normal input still produces the expected canonical args array `["port-forward", "-n", "production", "pod/nginx", "8080:80"]`.

All four tests pass against the patched code.

## Adversarial review

Before submitting, we tried to disprove the finding. We checked whether `spawn` without `shell: true` already neutralizes the issue — it doesn't, because the splitting happens in user-land JS before `spawn` ever sees the input, so `kubectl` itself receives the extra flags as legitimate argv entries. We also considered whether the attacker already has equivalent capability via being able to call the tool at all: they don't — normal invocation is bounded by the server's existing kubeconfig and a loopback bind, while the injection lets them point kubectl at a different cluster or expose the forward on all interfaces. No upstream Zod schema or MCP framework validation rejects spaces in these fields.

cc @lewiswigmore
