### PR TITLE
Enforce tool restrictions at tools/call layer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,23 @@ const allowedToolsEnv = process.env.ALLOWED_TOOLS;
 const nonDestructiveTools =
   process.env.ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS === "true";
 
+const explicitlyAllowedToolNames = allowedToolsEnv
+  ? new Set(allowedToolsEnv.split(",").map((t) => t.trim()).filter(Boolean))
+  : null;
+
+const isToolAllowed = (name: string): boolean => {
+  if (explicitlyAllowedToolNames) {
+    return explicitlyAllowedToolNames.has(name);
+  }
+  if (allowOnlyReadonlyTools) {
+    return readonlyTools.some((t) => t.name === name);
+  }
+  if (nonDestructiveTools) {
+    return !destructiveTools.some((dt) => dt.name === name);
+  }
+  return true;
+};
+
 // Define readonly tools
 const readonlyTools = [
   kubectlGetSchema,
@@ -184,21 +201,8 @@ registerPromptHandlers(server, k8sManager);
 
 // Tools handlers
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  let tools;
-
-  if (allowedToolsEnv) {
-    const allowedToolNames = allowedToolsEnv.split(",").map((t) => t.trim());
-    tools = allTools.filter((tool) => allowedToolNames.includes(tool.name));
-  } else if (allowOnlyReadonlyTools) {
-    tools = readonlyTools;
-  } else if (nonDestructiveTools) {
-    tools = allTools.filter(
-      (tool) => !destructiveTools.some((dt) => dt.name === tool.name)
-    );
-  } else {
-    tools = allTools;
-  }
-
+  const baseTools = allowOnlyReadonlyTools ? readonlyTools : allTools;
+  const tools = baseTools.filter((tool) => isToolAllowed(tool.name));
   return { tools };
 });
 
@@ -210,6 +214,13 @@ server.setRequestHandler(
   }) => {
     try {
       const { name, arguments: input = {} } = request.params;
+
+      if (!isToolAllowed(name)) {
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          `Tool '${name}' is not allowed under the current server configuration`
+        );
+      }
 
       // Handle new kubectl-style commands
       if (name === "kubectl_context") {

--- a/tests/tool_restriction_enforcement.test.ts
+++ b/tests/tool_restriction_enforcement.test.ts
@@ -1,0 +1,110 @@
+import { expect, test, describe, afterEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { z } from "zod";
+
+/**
+ * Verifies that tool-restriction environment variables
+ * (ALLOW_ONLY_READONLY_TOOLS, ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS, ALLOWED_TOOLS)
+ * are enforced at the tools/call layer in addition to tools/list.
+ *
+ * A client that knows a tool name must not be able to invoke a restricted
+ * tool directly by sending a tools/call request.
+ */
+describe("tool restriction enforcement (tools/call layer)", () => {
+  let transport: StdioClientTransport | undefined;
+  let client: Client | undefined;
+
+  async function connectWithEnv(env: Record<string, string>): Promise<Client> {
+    transport = new StdioClientTransport({
+      command: "bun",
+      args: ["src/index.ts"],
+      env: {
+        ...process.env,
+        ...env,
+      } as Record<string, string>,
+      stderr: "pipe",
+    });
+    client = new Client(
+      { name: "restriction-test-client", version: "1.0.0" },
+      { capabilities: {} }
+    );
+    await client.connect(transport);
+    return client;
+  }
+
+  afterEach(async () => {
+    try {
+      await client?.close();
+    } catch {}
+    try {
+      await transport?.close();
+    } catch {}
+    client = undefined;
+    transport = undefined;
+  });
+
+  test("ALLOW_ONLY_READONLY_TOOLS rejects a destructive tool at call-time", async () => {
+    const c = await connectWithEnv({ ALLOW_ONLY_READONLY_TOOLS: "true" });
+
+    const list = (await c.request(
+      { method: "tools/list", params: {} },
+      // @ts-ignore - minimal schema; we only inspect names
+      z.any()
+    )) as { tools: Array<{ name: string }> };
+    const names = list.tools.map((t) => t.name);
+    expect(names).not.toContain("kubectl_delete");
+
+    await expect(
+      c.request(
+        {
+          method: "tools/call",
+          params: {
+            name: "kubectl_delete",
+            arguments: { resourceType: "pod", name: "anything" },
+          },
+        },
+        // @ts-ignore - minimal schema
+        z.any()
+      )
+    ).rejects.toThrow(/not allowed/i);
+  }, 30000);
+
+  test("ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS rejects a destructive tool at call-time", async () => {
+    const c = await connectWithEnv({
+      ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS: "true",
+    });
+
+    await expect(
+      c.request(
+        {
+          method: "tools/call",
+          params: {
+            name: "kubectl_delete",
+            arguments: { resourceType: "pod", name: "anything" },
+          },
+        },
+        // @ts-ignore - minimal schema
+        z.any()
+      )
+    ).rejects.toThrow(/not allowed/i);
+  }, 30000);
+
+  test("ALLOWED_TOOLS allowlist rejects unlisted tools at call-time", async () => {
+    const c = await connectWithEnv({ ALLOWED_TOOLS: "kubectl_get,ping" });
+
+    await expect(
+      c.request(
+        {
+          method: "tools/call",
+          params: {
+            name: "kubectl_delete",
+            arguments: { resourceType: "pod", name: "anything" },
+          },
+        },
+        // @ts-ignore - minimal schema
+        z.any()
+      )
+    ).rejects.toThrow(/not allowed/i);
+  }, 30000);
+});


### PR DESCRIPTION
## Summary

- The tool restriction env vars (`ALLOW_ONLY_READONLY_TOOLS`, `ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS`, `ALLOWED_TOOLS`) were enforced only at `tools/list`. A client that knew (or guessed) a tool name could still invoke a restricted tool by sending a `tools/call` request directly — confirmed against a live cluster in all three modes.
- Centralize the allowlist logic in `isToolAllowed()` and gate the `CallTool` handler with it, so restricted tools are rejected with `InvalidRequest` before reaching any Kubernetes operation.
- `ListTools` now shares the same helper, so list/call behavior cannot drift apart.

## Test plan

- [x] `bun run test tests/tool_restriction_enforcement.test.ts` — new integration tests spawn the server under each restriction mode and verify `kubectl_delete` is rejected at call-time
- [x] `bun run test tests/non_destructive_tools.test.ts` — existing list-layer filter test still passes
- [x] `bun run build` — typecheck clean