### PR TITLE
Filter exec_in_pod when ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS is enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ const destructiveTools = [
   kubectlGenericSchema, // Generic kubectl command can perform destructive operations
 
   nodeManagementSchema, // Node management can drain nodes (destructive)
+  execInPodSchema, // Exec in pod can run arbitrary commands (destructive)
 ];
 
 // Get all available tools


### PR DESCRIPTION

exec_in_pod runs arbitrary commands inside a pod, which can mutate
cluster/workload state, so it belongs in the destructive tools list
alongside kubectl_delete, kubectl_generic, and node_management.
