### PR TITLE
Fix Helm schema for observability values

### DIFF
--- a/helm-chart/values.schema.json
+++ b/helm-chart/values.schema.json
@@ -297,6 +297,40 @@
     "nodeSelector": {"type": "object"},
     "tolerations": {"type": "array"},
     "affinity": {"type": "object"},
+    "observability": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "otlp": {
+          "type": "object",
+          "properties": {
+            "endpoint": {"type": "string"},
+            "protocol": {"type": "string"}
+          },
+          "additionalProperties": true
+        },
+        "sampling": {
+          "type": "object",
+          "properties": {
+            "type": {"type": "string"},
+            "ratio": {"type": "number"}
+          },
+          "additionalProperties": true
+        },
+        "serviceName": {"type": "string"},
+        "resourceAttributes": {"type": "object"},
+        "tls": {
+          "type": "object",
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "caCert": {"type": "string"},
+            "insecure": {"type": "boolean"}
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
     "env": {"type": "object"},
     "volumeMounts": {"type": "array"},
     "volumes": {"type": "array"},


### PR DESCRIPTION
Adds the missing observability schema entry so the chart's default values.yaml validates successfully. The chart already defines observability values and deployment templates reference .Values.observability.enabled.

<img width="733" height="101" alt="Screenshot 2026-06-08 at 10 59 15" src="https://github.com/user-attachments/assets/f02426e2-c34a-4c17-a358-63c8bd3eb70b" />