### PR TITLE
fix: sync server metadata version

### DIFF
--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -27,6 +27,10 @@ const files = [
     }
   },
   {
+    path: 'src/config/server-config.ts',
+    update: (content) => content.replace(/version:\s*"[^"]+"/, `version: "${version}"`)
+  },
+  {
     path: 'manifest.json',
     update: (content) => {
       const manifest = JSON.parse(content);
@@ -77,4 +81,4 @@ if (hasErrors) {
   process.exit(1);
 } else {
   console.log(`\n🎉 All files updated to version ${version}`);
-} 
+}

--- a/src/config/server-config.ts
+++ b/src/config/server-config.ts
@@ -1,6 +1,6 @@
 export const serverConfig = {
   name: "kubernetes",
-  version: "0.1.0",
+  version: "3.9.0",
   capabilities: {
     resources: {},
     tools: {},

--- a/src/middleware/telemetry-middleware.ts
+++ b/src/middleware/telemetry-middleware.ts
@@ -1,5 +1,6 @@
 import { trace, context, SpanStatusCode, Span } from "@opentelemetry/api";
 import { CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { serverConfig } from "../config/server-config.js";
 import { getTelemetryConfig } from "../config/telemetry-config.js";
 
 /**
@@ -8,7 +9,7 @@ import { getTelemetryConfig } from "../config/telemetry-config.js";
  */
 
 // Get tracer instance
-const tracer = trace.getTracer("mcp-server-kubernetes", "0.1.0");
+const tracer = trace.getTracer(serverConfig.name, serverConfig.version);
 
 /**
  * Tool call handler function type

--- a/tests/server-config.test.ts
+++ b/tests/server-config.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { serverConfig } from '../src/config/server-config.js';
+
+describe('serverConfig', () => {
+  it('reports the package version in server metadata', () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+    ) as { version: string };
+
+    expect(serverConfig.version).toBe(pkg.version);
+  });
+});

--- a/tests/telemetry-config.test.ts
+++ b/tests/telemetry-config.test.ts
@@ -302,7 +302,7 @@ describe('Telemetry Configuration', () => {
       const summary = getTelemetryConfigSummary();
       expect(summary).toContain('Telemetry: Enabled');
       expect(summary).toContain('Endpoint: http://localhost:4317');
-      expect(summary).toContain('Service: kubernetes@0.1.0');
+      expect(summary).toContain('Service: kubernetes@3.9.0');
     });
 
     it('should include sampler in summary', () => {


### PR DESCRIPTION
## Summary
- update `serverConfig.version` to match the published package version
- make `scripts/update-version.js` update `src/config/server-config.ts` during future releases
- reuse `serverConfig` for the OpenTelemetry tracer version and add a regression test

Fixes #319

## Test plan
- `bun run test tests/server-config.test.ts tests/telemetry-config.test.ts`
- `bun run build`