### PR TITLE
Add allNamespaces parameter to kubectl_generic for consistency with other tools

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -92,7 +92,7 @@ jobs:
           # Update the version in all files using the npm script
           npm run version:update ${{ steps.version.outputs.current-version }}
 
-          git add package.json manifest.json CITATION.cff README.md gemini-extension.json
+          git add package.json src/config/server-config.ts manifest.json CITATION.cff README.md gemini-extension.json
           git commit -m "Bump version to ${{ steps.version.outputs.current-version }}"
 
           # Create and push the tag

--- a/src/config/server-config.ts
+++ b/src/config/server-config.ts
@@ -1,6 +1,6 @@
 export const serverConfig = {
   name: "kubernetes",
-  version: "3.9.1",
+  version: "3.9.2",
   capabilities: {
     resources: {},
     tools: {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -385,6 +385,7 @@ server.setRequestHandler(
             resourceType?: string;
             name?: string;
             namespace?: string;
+            allNamespaces?: boolean;
             outputFormat?: string;
             flags?: Record<string, any>;
             args?: string[];

--- a/src/tools/kubectl-generic.ts
+++ b/src/tools/kubectl-generic.ts
@@ -36,6 +36,11 @@ export const kubectlGenericSchema = {
         description: "Resource name",
       },
       namespace: namespaceParameter,
+      allNamespaces: {
+        type: "boolean",
+        description: "If true, run the command across all namespaces",
+        default: false,
+      },
       outputFormat: {
         type: "string",
         description: "Output format (e.g. json, yaml, wide)",
@@ -65,6 +70,7 @@ export async function kubectlGeneric(
     resourceType?: string;
     name?: string;
     namespace?: string;
+    allNamespaces?: boolean;
     outputFormat?: string;
     flags?: Record<string, any>;
     args?: string[];
@@ -95,8 +101,11 @@ export async function kubectlGeneric(
       cmdArgs.push(input.name);
     }
 
-    // Add namespace if provided
-    if (input.namespace) {
+    // Add namespace scoping: --all-namespaces takes precedence over a
+    // specific namespace (kubectl rejects using both together)
+    if (input.allNamespaces) {
+      cmdArgs.push("--all-namespaces");
+    } else if (input.namespace) {
       cmdArgs.push(`--namespace=${input.namespace}`);
     }
 

--- a/tests/kubectl-generic.test.ts
+++ b/tests/kubectl-generic.test.ts
@@ -328,6 +328,32 @@ describe("kubectl_generic command", () => {
     expect(deleteResult.content[0].text).toContain("deleted");
   });
 
+  test("kubectl_generic supports allNamespaces parameter", async () => {
+    // Get pods across all namespaces using the allNamespaces parameter,
+    // also passing a namespace to verify allNamespaces takes precedence
+    const result = await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "kubectl_generic",
+          arguments: {
+            command: "get",
+            resourceType: "pods",
+            namespace: "default",
+            allNamespaces: true
+          },
+        },
+      },
+      z.any()
+    ) as KubectlResponse;
+
+    expect(result.content[0].type).toBe("text");
+    // With --all-namespaces, kubectl adds a NAMESPACE column
+    expect(result.content[0].text).toMatch(/NAMESPACE\s+NAME/);
+    // kube-system pods should be included, proving it's not scoped to default
+    expect(result.content[0].text).toContain("kube-system");
+  });
+
   test("kubectl_generic handles errors gracefully", async () => {
     const nonExistentResource = "non-existent-resource-" + Date.now();
     


### PR DESCRIPTION
## Summary

Fixes #326 — `kubectl_generic` silently ignored the `allNamespaces` parameter because it was never defined in the tool's input schema, so calls like `top pods` with `allNamespaces: true` only returned results from the default namespace.

This wires up `allNamespaces` the same way the dedicated tools (`kubectl_get`, `kubectl_describe`, `kubectl_delete`) handle it:

- Added `allNamespaces` (boolean, default `false`) to the `kubectl_generic` input schema and handler signature
- When `allNamespaces` is true, the command builder pushes `--all-namespaces` and skips the `--namespace` flag, since kubectl rejects using both together

## CI fix: version mismatch in server-config

CI was failing on an unrelated pre-existing issue: `scripts/update-version.js` updates the version in `src/config/server-config.ts`, but the CD workflow's commit step never `git add`ed that file, so main ended up with `package.json` at 3.9.2 while `serverConfig.version` stayed at 3.9.1 — failing `tests/server-config.test.ts` on every PR. This PR:

- Syncs `src/config/server-config.ts` to 3.9.2
- Adds `src/config/server-config.ts` to the `git add` list in `.github/workflows/cd.yml` so future automated bumps commit it

## Testing

- Added an integration test that calls `kubectl_generic` with `command: get`, `resourceType: pods`, `namespace: default`, and `allNamespaces: true`, asserting the output includes the NAMESPACE column and kube-system pods (proving precedence over the explicit namespace)
- `bun run build` passes; all 6 tests in `tests/kubectl-generic.test.ts` and `tests/server-config.test.ts` pass locally against a live cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Flux159/mcp-server-kubernetes/pull/327).
