### PR TITLE
Guard port_forward argv against flag injection

### DIFF
--- a/src/tools/port_forward.ts
+++ b/src/tools/port_forward.ts
@@ -1,11 +1,18 @@
 import { spawn } from "child_process";
 import { z } from "zod";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import { KubernetesManager } from "../utils/kubernetes-manager.js";
+import { assertSafeArgv } from "../security/kubectl-flags.js";
 
 // Use spawn instead of exec because port-forward is a long-running process
 async function executePortForward(
   args: string[]
 ): Promise<{ success: boolean; message: string; pid: number }> {
+  // port_forward uses spawn (long-running process) rather than the shared
+  // execFileSyncSafe wrapper, so it must run the argv guard itself. Otherwise
+  // user-supplied values pushed into positional slots (e.g. resourceType) can
+  // smuggle credential/target-redirecting flags such as --server.
+  assertSafeArgv(args);
   return new Promise((resolve, reject) => {
     const process = spawn("kubectl", args);
 
@@ -122,6 +129,9 @@ export async function startPortForward(
       ],
     };
   } catch (error: any) {
+    // Preserve McpError (e.g. the argv safety guard's InvalidParams rejection)
+    // so the client sees the real reason instead of a generic InternalError.
+    if (error instanceof McpError) throw error;
     throw new Error(`Failed to execute port-forward: ${error.message}`);
   }
 }

--- a/tests/kubectl-flags-security.unit.test.ts
+++ b/tests/kubectl-flags-security.unit.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../src/security/kubectl-flags.js";
 import { kubectlGeneric } from "../src/tools/kubectl-generic.js";
 import { kubectlGet } from "../src/tools/kubectl-get.js";
+import { startPortForward } from "../src/tools/port_forward.js";
 import { KubernetesManager } from "../src/utils/kubernetes-manager.js";
 
 describe("assertNoDangerousFlags", () => {
@@ -332,5 +333,36 @@ describe("sibling tools refuse the positional flag-injection PoC", () => {
         name: "--server=https://attacker.example.com",
       })
     ).rejects.toThrow(/--server/);
+  });
+
+  // port_forward uses spawn (long-running process) instead of the shared
+  // execFileSyncSafe wrapper, so it guards its own argv. resourceType is pushed
+  // into a positional slot as `${resourceType}/${resourceName}`, so a payload
+  // like resourceType="--server=..." would otherwise redirect kubectl.
+  test("port_forward blocks resourceType='--server=...' before spawning", async () => {
+    await expect(
+      startPortForward(stubManager, {
+        resourceType: "--server=https://127.0.0.1:19099",
+        resourceName: "web",
+        localPort: 8080,
+        targetPort: 80,
+        namespace: "default",
+      })
+    ).rejects.toThrow(/--server/);
+  });
+
+  test("port_forward rejection is an McpError with InvalidParams code", async () => {
+    try {
+      await startPortForward(stubManager, {
+        resourceType: "--server=https://attacker",
+        resourceName: "web",
+        localPort: 8080,
+        targetPort: 80,
+      });
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(McpError);
+      expect((e as McpError).code).toBe(ErrorCode.InvalidParams);
+    }
   });
 });


### PR DESCRIPTION

port_forward uses spawn() for the long-running process instead of the
shared execFileSyncSafe wrapper, so it never ran assertSafeArgv. Its argv
includes user-supplied resourceType pushed as `${resourceType}/${resourceName}`,
so resourceType="--server=https://attacker" produced the token
"--server=https://attacker/name", which kubectl's pflag parser honors and
uses to redirect the API server and leak the operator's bearer token.

This closes the last unguarded exec path from the argument-injection report
(GHSA-qmcc-whxh-2p3p / #328); the structured tools were already covered by
execFileSyncSafe.

- Call assertSafeArgv(args) before spawn in port_forward
- Preserve the McpError (InvalidParams) through startPortForward's catch
- Add regression tests for the port_forward PoC

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Flux159/mcp-server-kubernetes/pull/329).
* __->__ #329
* #327