### PR TITLE
Mask Secret data regardless of resourceType syntax

### DIFF
--- a/src/tools/kubectl-get.ts
+++ b/src/tools/kubectl-get.ts
@@ -161,10 +161,14 @@ export async function kubectlGet(
         env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
       });
 
-      // Apply secrets masking if enabled and dealing with secrets
+      // Apply secrets masking if enabled and dealing with secrets.
+      // resourceReferencesSecret normalizes combined forms like
+      // "secret/my-secret", group-qualified "secrets.v1./my-secret", and
+      // comma-separated lists ("secret,configmap") so the masking decision
+      // cannot be bypassed by addressing a Secret through an alternate syntax.
       const shouldMaskSecrets =
         process.env.MASK_SECRETS !== "false" &&
-        (resourceType === "secrets" || resourceType === "secret");
+        resourceReferencesSecret(resourceType);
 
       let processedResult = result;
       if (shouldMaskSecrets) {
@@ -426,10 +430,57 @@ function isNonNamespacedResource(resourceType: string): boolean {
 }
 
 /**
- * Recursively traverses an object and masks values in 'data' sections of Kubernetes secrets.
+ * Determine whether a (already lower-cased) resourceType string references
+ * Kubernetes Secrets in any of the syntaxes kubectl accepts. This backs the
+ * masking decision, so it must recognize every way a caller could name a
+ * Secret without tripping the naive "=== 'secret'" check:
+ *   - plain:            "secret", "secrets"
+ *   - resource/name:    "secret/my-secret"
+ *   - group-qualified:  "secrets.v1.", "secret.example.com/my-secret"
+ *   - comma-separated:  "secret,configmap"
+ *
+ * @param {string} resourceType - The lower-cased resourceType argument.
+ * @returns {boolean} True if any referenced resource is a Secret.
+ */
+export function resourceReferencesSecret(resourceType: string): boolean {
+  return resourceType
+    .split(",")
+    .map((part) => {
+      // Drop the "/name" portion of a resource/name reference, then the
+      // ".group"/".version" suffix of a group-qualified reference.
+      const resource = part.trim().split("/")[0].split(".")[0];
+      return resource.toLowerCase();
+    })
+    .some((resource) => resource === "secret" || resource === "secrets");
+}
+
+// Mask the leaf values of a single Secret object's `data` (and write-only
+// `stringData`) fields, leaving metadata and every other field intact.
+function maskSecretObject(secret: any): any {
+  const result: any = {};
+  for (const key in secret) {
+    if (
+      (key === "data" || key === "stringData") &&
+      typeof secret[key] === "object" &&
+      secret[key] !== null
+    ) {
+      result[key] = maskAllLeafValues(secret[key]);
+    } else {
+      result[key] = maskDataValues(secret[key]);
+    }
+  }
+  return result;
+}
+
+/**
+ * Recursively traverses a parsed kubectl response and masks the `data` values
+ * of Kubernetes Secrets only. Masking is scoped by object kind rather than by
+ * the presence of a "data" key, so that Secret values are always masked (even
+ * inside a mixed `List` returned by e.g. `kubectl get secret,configmap`) while
+ * non-Secret resources such as ConfigMaps keep their data.
  *
  * @param {any} obj - The object to traverse. Can be an array, object, or primitive value.
- * @returns {any} A new object with masked values in 'data' sections.
+ * @returns {any} A new object with masked values in Secret 'data' sections.
  */
 function maskDataValues(obj: any): any {
   if (obj == null) {
@@ -441,14 +492,28 @@ function maskDataValues(obj: any): any {
   }
 
   if (typeof obj === "object") {
+    const kind =
+      typeof obj.kind === "string" ? obj.kind.toLowerCase() : undefined;
+
+    // A single Secret object.
+    if (kind === "secret") {
+      return maskSecretObject(obj);
+    }
+
+    // A SecretList: every item is a Secret, even when kubectl omits the
+    // per-item `kind` field in list output, so mask them unconditionally.
+    if (kind === "secretlist" && Array.isArray(obj.items)) {
+      return {
+        ...obj,
+        items: obj.items.map((item: any) => maskSecretObject(item)),
+      };
+    }
+
+    // Any other object (including a heterogeneous "List"): recurse so nested
+    // Secret objects are still masked without touching non-Secret data.
     const result: any = {};
     for (const key in obj) {
-      if (key === "data" && typeof obj[key] === "object" && obj[key] !== null) {
-        // This is a data section - mask all leaf values within it
-        result[key] = maskAllLeafValues(obj[key]);
-      } else {
-        result[key] = maskDataValues(obj[key]);
-      }
+      result[key] = maskDataValues(obj[key]);
     }
     return result;
   }
@@ -493,7 +558,7 @@ function maskAllLeafValues(obj: any): any {
  * @param {string} format - The format of the output, either "json" or "yaml".
  * @returns {string} - The masked output in the same format as the input.
  */
-function maskSecretsData(output: string, format: string): string {
+export function maskSecretsData(output: string, format: string): string {
   try {
     if (format === "json") {
       const parsed = JSON.parse(output);


### PR DESCRIPTION

kubectl_get only masked Secret data values when resourceType was exactly
"secret" or "secrets". Kubernetes also accepts combined forms such as
"secret/my-secret", so a caller could request a Secret via
resourceType="secret/<name>" (no separate name) and receive unmasked data,
bypassing the MASK_SECRETS output-masking control (GHSA-w23h-64x4-22h9).

- resourceReferencesSecret normalizes resource/name, group-qualified, and
  comma-separated forms for the masking decision.
- maskDataValues now masks by object kind (Secret / SecretList items) instead
  of any "data" key, so masking holds for mixed lists while ConfigMap data is
  left untouched (defense in depth per the advisory).
- Add unit tests for the normalization and kind-scoped masking.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
