### PR TITLE
kubectl_create: support inline file content, restrict server-side path reads on remote transports

### DIFF
--- a/src/security/transport.ts
+++ b/src/security/transport.ts
@@ -1,0 +1,19 @@
+// Transport-mode detection for security decisions.
+//
+// The server selects its transport at startup based on these env vars (see
+// src/index.ts): if either is set the server listens over HTTP (SSE or
+// Streamable HTTP) and serves remote clients; otherwise it uses stdio and is
+// driven by a local process that already runs as the operator.
+//
+// Some tool inputs are only safe under the stdio trust model. A server-side
+// filesystem path (e.g. `--from-file` / `-f`) is read on the machine running
+// the server: over stdio that machine is the operator's own, but over HTTP it
+// is the server host, so any client that can reach the endpoint could read
+// arbitrary files (kubeconfig, service-account token, /proc/self/environ).
+// Guards use this helper to reject path-based reads on remote transports.
+export function isRemoteTransport(): boolean {
+  return Boolean(
+    process.env.ENABLE_UNSAFE_SSE_TRANSPORT ||
+      process.env.ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT
+  );
+}

--- a/src/tools/kubectl-create.ts
+++ b/src/tools/kubectl-create.ts
@@ -6,6 +6,7 @@ import * as path from "path";
 import * as os from "os";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import { contextParameter, namespaceParameter, dryRunParameter } from "../models/common-parameters.js";
+import { isRemoteTransport } from "../security/transport.js";
 
 export const kubectlCreateSchema = {
   name: "kubectl_create",
@@ -47,7 +48,8 @@ export const kubectlCreateSchema = {
       },
       filename: {
         type: "string",
-        description: "Path to a YAML file to create resources from",
+        description:
+          "Path to a YAML file to create resources from. The path is read on the machine running the MCP server, so it is rejected when the server runs over a remote (SSE/Streamable HTTP) transport; use 'manifest' to pass the file's contents instead.",
       },
 
       // Resource type to create (determines which subcommand to use)
@@ -75,7 +77,28 @@ export const kubectlCreateSchema = {
         type: "array",
         items: { type: "string" },
         description:
-          'Path to file for creating configmap (e.g. ["key1=/path/to/file1", "key2=/path/to/file2"])',
+          'Path to file for creating configmap/secret (e.g. ["key1=/path/to/file1", "key2=/path/to/file2"]). The path is read on the machine running the MCP server, so it is rejected when the server runs over a remote (SSE/Streamable HTTP) transport; use "fromFileContent" to pass file contents directly instead.',
+      },
+      fromFileContent: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            key: {
+              type: "string",
+              description:
+                "Key to store the content under in the configmap/secret",
+            },
+            content: {
+              type: "string",
+              description: "The file content to store",
+            },
+          },
+          required: ["key", "content"],
+          additionalProperties: false,
+        },
+        description:
+          'Inline file contents for creating a configmap/secret, provided by the client instead of a server-side path (e.g. [{"key": "app.conf", "content": "..."}]). Safe on all transports; use this instead of "fromFile" on remote (SSE/Streamable HTTP) servers.',
       },
 
       // Namespace specific parameters
@@ -175,6 +198,7 @@ export async function kubectlCreate(
     // ConfigMap specific
     fromLiteral?: string[];
     fromFile?: string[];
+    fromFileContent?: { key: string; content: string }[];
 
     // Secret specific
     secretType?: "generic" | "docker-registry" | "tls";
@@ -220,6 +244,28 @@ export async function kubectlCreate(
       );
     }
 
+    // Reject server-side filesystem reads on remote transports. Over SSE /
+    // Streamable HTTP the path resolves on the MCP server host, not the
+    // client, so `filename` (-f) and `fromFile` (--from-file) would let any
+    // client that can reach the endpoint read arbitrary server files
+    // (kubeconfig, service-account token, /proc/self/environ, etc.). See
+    // GHSA-m67f-jxm9-cvx8. Clients on these transports must pass content
+    // inline via `manifest` or `fromFileContent` instead.
+    if (isRemoteTransport()) {
+      if (input.filename) {
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          "The 'filename' parameter reads a file from the MCP server's filesystem and is disabled on remote (SSE/Streamable HTTP) transports. Pass the file contents via 'manifest' instead."
+        );
+      }
+      if (input.fromFile && input.fromFile.length > 0) {
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          "The 'fromFile' parameter reads files from the MCP server's filesystem and is disabled on remote (SSE/Streamable HTTP) transports. Pass the file contents via 'fromFileContent' instead."
+        );
+      }
+    }
+
     // Set up common parameters
     const namespace = input.namespace || "default";
     const dryRun = input.dryRun || false;
@@ -229,16 +275,48 @@ export async function kubectlCreate(
 
     const command = "kubectl";
     const args = ["create"];
-    let tempFile: string | null = null;
+    const tempFiles: string[] = [];
+
+    // Write client-provided content to a private temp file and return its
+    // path. The file is tracked for cleanup after kubectl runs.
+    const writeTempFile = (
+      contents: string,
+      label: string,
+      ext = ""
+    ): string => {
+      const tmpDir = os.tmpdir();
+      const tempFile = path.join(
+        tmpDir,
+        `create-${label}-${Date.now()}-${tempFiles.length}${ext}`
+      );
+      fs.writeFileSync(tempFile, contents, { mode: 0o600 });
+      tempFiles.push(tempFile);
+      return tempFile;
+    };
+
+    // Emit `--from-file=<key>=<tempfile>` args for inline content supplied by
+    // the client. Each entry's content is written to a server-side temp file
+    // (never a client-controlled path), so this is safe on all transports.
+    const pushFromFileContent = (
+      entries: { key: string; content: string }[]
+    ) => {
+      entries.forEach((entry) => {
+        if (!entry.key) {
+          throw new McpError(
+            ErrorCode.InvalidRequest,
+            "Each fromFileContent entry requires a non-empty 'key'"
+          );
+        }
+        const tempFile = writeTempFile(entry.content ?? "", "fromfile");
+        args.push(`--from-file=${entry.key}=${tempFile}`);
+      });
+    };
 
     // Process manifest content if provided (file-based creation)
     if (input.manifest || input.filename) {
       if (input.manifest) {
         // Create temporary file for the manifest
-        const tmpDir = os.tmpdir();
-        tempFile = path.join(tmpDir, `create-manifest-${Date.now()}.yaml`);
-        fs.writeFileSync(tempFile, input.manifest);
-        args.push("-f", tempFile);
+        args.push("-f", writeTempFile(input.manifest, "manifest", ".yaml"));
       } else if (input.filename) {
         args.push("-f", input.filename);
       }
@@ -259,11 +337,17 @@ export async function kubectlCreate(
             });
           }
 
-          // Add --from-file arguments
+          // Add --from-file arguments (server-side paths; blocked on remote
+          // transports by the guard above)
           if (input.fromFile && input.fromFile.length > 0) {
             input.fromFile.forEach((file) => {
               args.push(`--from-file=${file}`);
             });
+          }
+
+          // Add inline file contents (safe on all transports)
+          if (input.fromFileContent && input.fromFileContent.length > 0) {
+            pushFromFileContent(input.fromFileContent);
           }
           break;
 
@@ -284,11 +368,17 @@ export async function kubectlCreate(
             });
           }
 
-          // Add --from-file arguments
+          // Add --from-file arguments (server-side paths; blocked on remote
+          // transports by the guard above)
           if (input.fromFile && input.fromFile.length > 0) {
             input.fromFile.forEach((file) => {
               args.push(`--from-file=${file}`);
             });
+          }
+
+          // Add inline file contents (safe on all transports)
+          if (input.fromFileContent && input.fromFileContent.length > 0) {
+            pushFromFileContent(input.fromFileContent);
           }
           break;
 
@@ -423,6 +513,17 @@ export async function kubectlCreate(
       args.push("--context", context);
     }
 
+    // Remove any temp files created for inline content.
+    const cleanupTempFiles = () => {
+      tempFiles.forEach((tempFile) => {
+        try {
+          fs.unlinkSync(tempFile);
+        } catch (err) {
+          console.warn(`Failed to delete temporary file ${tempFile}: ${err}`);
+        }
+      });
+    };
+
     // Execute the command
     try {
       const result = execFileSyncSafe(command, args, {
@@ -431,14 +532,8 @@ export async function kubectlCreate(
         env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
       });
 
-      // Clean up temp file if created
-      if (tempFile) {
-        try {
-          fs.unlinkSync(tempFile);
-        } catch (err) {
-          console.warn(`Failed to delete temporary file ${tempFile}: ${err}`);
-        }
-      }
+      // Clean up temp files if created
+      cleanupTempFiles();
 
       return {
         content: [
@@ -449,14 +544,8 @@ export async function kubectlCreate(
         ],
       };
     } catch (error: any) {
-      // Clean up temp file if created, even if command failed
-      if (tempFile) {
-        try {
-          fs.unlinkSync(tempFile);
-        } catch (err) {
-          console.warn(`Failed to delete temporary file ${tempFile}: ${err}`);
-        }
-      }
+      // Clean up temp files if created, even if command failed
+      cleanupTempFiles();
 
       throw new McpError(
         ErrorCode.InternalError,

--- a/tests/kubectl-create-from-file.unit.test.ts
+++ b/tests/kubectl-create-from-file.unit.test.ts
@@ -1,0 +1,109 @@
+import { expect, test, describe, beforeEach, afterEach } from "vitest";
+import { isRemoteTransport } from "../src/security/transport.js";
+import { kubectlCreate } from "../src/tools/kubectl-create.js";
+
+// GHSA-m67f-jxm9-cvx8: on remote (SSE / Streamable HTTP) transports the
+// server-side path params `filename` (-f) and `fromFile` (--from-file) let any
+// client read arbitrary files from the MCP server host. These must be rejected
+// before kubectl runs, and clients steered to the inline-content params
+// (`manifest`, `fromFileContent`) which are safe on all transports.
+
+const TRANSPORT_ENV = [
+  "ENABLE_UNSAFE_SSE_TRANSPORT",
+  "ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT",
+] as const;
+
+describe("isRemoteTransport", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    TRANSPORT_ENV.forEach((k) => {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    });
+  });
+
+  afterEach(() => {
+    TRANSPORT_ENV.forEach((k) => {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    });
+  });
+
+  test("false when no transport env var is set (stdio)", () => {
+    expect(isRemoteTransport()).toBe(false);
+  });
+
+  test("true when the SSE transport is enabled", () => {
+    process.env.ENABLE_UNSAFE_SSE_TRANSPORT = "true";
+    expect(isRemoteTransport()).toBe(true);
+  });
+
+  test("true when the Streamable HTTP transport is enabled", () => {
+    process.env.ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT = "true";
+    expect(isRemoteTransport()).toBe(true);
+  });
+});
+
+describe("kubectlCreate rejects server-side file reads on remote transports", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    TRANSPORT_ENV.forEach((k) => {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    });
+  });
+
+  afterEach(() => {
+    TRANSPORT_ENV.forEach((k) => {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    });
+  });
+
+  // The guard runs before any kubectl execution, so a stub manager is fine.
+  const manager = {} as any;
+
+  for (const envVar of TRANSPORT_ENV) {
+    test(`rejects fromFile under ${envVar}`, async () => {
+      process.env[envVar] = "true";
+      await expect(
+        kubectlCreate(manager, {
+          resourceType: "configmap",
+          name: "leak",
+          fromFile: ["/etc/passwd"],
+          dryRun: true,
+        })
+      ).rejects.toThrow(/'fromFile'.*disabled on remote/s);
+    });
+
+    test(`rejects filename under ${envVar}`, async () => {
+      process.env[envVar] = "true";
+      await expect(
+        kubectlCreate(manager, {
+          filename: "/etc/passwd",
+          dryRun: true,
+        })
+      ).rejects.toThrow(/'filename'.*disabled on remote/s);
+    });
+  }
+
+  test("allows fromFileContent under a remote transport", async () => {
+    process.env.ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT = "true";
+    // The inline-content path carries no server-side path, so it is safe on
+    // remote transports. dryRun renders the resource without touching the
+    // cluster; the client-provided content lands under the requested key.
+    const result: any = await kubectlCreate(manager, {
+      resourceType: "configmap",
+      name: "cfg",
+      fromFileContent: [{ key: "app.conf", content: "hello=world" }],
+      dryRun: true,
+    });
+    const text = result.content[0].text;
+    expect(text).toMatch(/app\.conf: hello=world/);
+    expect(text).toMatch(/kind: ConfigMap/);
+  });
+});


### PR DESCRIPTION
## Summary

Hardens `kubectl_create` for remote (SSE / Streamable HTTP) deployments and adds an inline-content option for ConfigMaps/Secrets.

The `filename` (`-f`) and `fromFile` (`--from-file`) parameters resolve a path on the machine running the MCP server. That matches local CLI expectations under stdio, but for a server accepting requests from remote clients the path no longer refers to the client's machine. This PR keeps the existing behavior for stdio and adds a transport-appropriate path for remote deployments.

## Changes

**1. Restrict server-side path parameters to stdio.**
`filename` and `fromFile` are now rejected with `InvalidRequest` when the server runs over a remote transport, detected via the same `ENABLE_UNSAFE_SSE_TRANSPORT` / `ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT` env vars used to select the transport at startup (new helper `src/security/transport.ts::isRemoteTransport()`). **stdio behavior is unchanged.**

**2. Add `fromFileContent` for inline content.**
A new `fromFileContent: { key, content }[]` parameter carries file contents supplied by the client. Each entry is written to a private (`0600`) server-side temp file and passed as `--from-file=<key>=<tempfile>`, then cleaned up after kubectl runs. It works on all transports and is the recommended way to populate ConfigMaps/Secrets on remote servers — mirroring the existing `manifest`-vs-`filename` split.

## Tests

`tests/kubectl-create-from-file.unit.test.ts`:
- `isRemoteTransport()` reflects each transport env var
- `filename` / `fromFile` are rejected under both SSE and Streamable HTTP
- `fromFileContent` renders correctly (verified end-to-end against a live cluster with `dryRun`)

All 8 tests pass; `tsc --noEmit` clean.

## Compatibility

No change for stdio deployments. Remote (HTTP) deployments that used `fromFile`/`filename` should switch to `fromFileContent`/`manifest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)