### PR TITLE
cd: use Node 24 for the npm publish job (fixes broken releases)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Setup Node.js for NPM publish
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm for OIDC support


### PR DESCRIPTION
## Problem

The CD workflow's release publish is broken. The **Update npm for OIDC support** step runs `npm install -g npm@latest`, but `npm@latest` is now **12.0.1**, which requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`. The publish job pins **Node 20** (now EOL), so the install fails:

```
npm error code EBADENGINE
npm error notsup Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

The job fails before publishing, so nothing reaches npm / GHCR / Docker Hub.

## Fix

Bump the **Setup Node.js for NPM publish** step from Node 20 to Node 24, which satisfies `npm@latest`'s engine requirement. Only the publish job's Node version changes; the earlier test job is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)