### PR TITLE
README: add HVTrust badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/Flux159/mcp-server-kubernetes/pulls)
 [![Last Commit](https://img.shields.io/github/last-commit/Flux159/mcp-server-kubernetes)](https://github.com/Flux159/mcp-server-kubernetes/commits/main)
 [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/Flux159/mcp-server-kubernetes)](https://archestra.ai/mcp-catalog/flux159__mcp-server-kubernetes)
+[![HVTrust](https://hvtracker.net/badge/kubernetes-mcp-server.svg)](https://hvtracker.net/agents/kubernetes-mcp-server/)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Flux159/mcp-server-kubernetes)
 
 <p align="center">


### PR DESCRIPTION
As requested in #334 — one line, placed next to the existing Archestra trust badge.

```markdown
[![HVTrust](https://hvtracker.net/badge/kubernetes-mcp-server.svg)](https://hvtracker.net/agents/kubernetes-mcp-server/)
```

The badge is rendered live, so it **auto-updates as the score changes** — no maintenance on your side, and it can't go stale.

**Where this project currently stands:** [HVTrust 83.3 · Grade A](https://hvtracker.net/agents/kubernetes-mcp-server/) — rank #37 of 371 tracked projects, and #4 among MCP servers. MIT licensed, build provenance present, OSSF Scorecard 5.6/10.

A couple of things worth knowing, since a badge is only as good as what's behind it:

- The full evidence breakdown — every signal, with the scan date — is on [your agent page](https://hvtracker.net/agents/kubernetes-mcp-server/), and the scoring is documented at [hvtracker.net/methodology](https://hvtracker.net/methodology/#hvtrust-production-rank). No pay-to-rank; the score moves only on public, checkable signals.
- **The score can go down as well as up.** If that's not something you want on your README, that's a completely reasonable reason to close this.
- If any signal looks wrong, we correct on evidence, no account needed: [hvtracker.net/correct](https://hvtracker.net/correct/).

Prefer a letter grade instead of the number? Swap the image URL for `kubernetes-mcp-server-grade.svg`. Happy to adjust placement or drop it entirely — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)