### PR TITLE
fix(kubectl-logs): unbreak logs under shell-less execFileSync

### DIFF
--- a/src/tools/kubectl-logs.ts
+++ b/src/tools/kubectl-logs.ts
@@ -87,7 +87,7 @@ export async function kubectlLogs(
   }
 ) {
   try {
-    const resourceType = input.resourceType.toLowerCase();
+    const resourceType = (input.resourceType ?? "pod").toLowerCase();
     const name = input.name;
     const namespace = input.namespace || "default";
     const context = input.context || "";
@@ -138,7 +138,7 @@ export async function kubectlLogs(
           "deployment",
           name,
           "-o",
-          "jsonpath='{.spec.selector.matchLabels}'",
+          "jsonpath={.spec.selector.matchLabels}",
         ];
       } else if (resourceType === "job") {
         // For jobs, we use the job-name label
@@ -152,7 +152,7 @@ export async function kubectlLogs(
           "jobs",
           "--selector=job-name=" + name,
           "-o",
-          "jsonpath='{.items[*].metadata.name}'",
+          "jsonpath={.items[*].metadata.name}",
         ];
         try {
           const jobs = execFileSyncSafe(command, jobsArgs, {
@@ -226,7 +226,7 @@ export async function kubectlLogs(
             maxBuffer: getSpawnMaxBuffer(),
             env: { ...process.env, KUBECONFIG: process.env.KUBECONFIG },
           }).trim();
-          const selector = JSON.parse(selectorJson.replace(/'/g, '"'));
+          const selector = JSON.parse(selectorJson);
 
           // Convert to label selector format
           const labelSelector = Object.entries(selector)
@@ -323,7 +323,7 @@ async function getLabelSelectorLogs(
       "pods",
       `--selector=${labelSelector}`,
       "-o",
-      "jsonpath='{.items[*].metadata.name}'",
+      "jsonpath={.items[*].metadata.name}",
     ];
     const pods = execFileSyncSafe(command, podsArgs, {
       encoding: "utf8",

--- a/tests/kubectl-logs.unit.test.ts
+++ b/tests/kubectl-logs.unit.test.ts
@@ -1,0 +1,174 @@
+import { expect, test, describe, vi, beforeEach, afterEach } from "vitest";
+import { kubectlLogs } from "../src/tools/kubectl-logs.js";
+import { KubernetesManager } from "../src/utils/kubernetes-manager.js";
+import { execFileSync } from "child_process";
+
+/**
+ * Unit tests for the kubectl_logs tool.
+ *
+ * Regression coverage for two bugs that made every log fetch fail on
+ * flux159/mcp-server-kubernetes v3.9.0 once the tool moved to shell-less
+ * execFileSync:
+ *
+ *  1. Pod path threw "Cannot read properties of undefined (reading
+ *     'toLowerCase')" whenever resourceType was omitted, because the schema
+ *     marks it required but the MCP SDK does not enforce it, so `undefined`
+ *     reached `input.resourceType.toLowerCase()`.
+ *
+ *  2. Deployment/job/cronjob path built `-o jsonpath='{...}'` with LITERAL
+ *     single quotes. Under execFileSync (no shell to strip them) kubectl
+ *     emitted `'{"k8s-app":"kube-dns"}'`; the handler then did
+ *     `.replace(/'/g, '"')` -> `"{"k8s-app"...` and JSON.parse died with
+ *     "Unexpected non-whitespace character after JSON at position 3".
+ *
+ * Strategy: mock child_process.execFileSync (which execFileSyncSafe calls) so
+ * we can assert both the exact argv kubectl receives and that plain-text log
+ * output is returned verbatim rather than parsed as JSON.
+ */
+
+vi.mock("child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+// A plain-text log line whose 4th character (position 3) is non-whitespace,
+// i.e. exactly the shape that broke JSON.parse in the original bug. If any
+// code path ever JSON.parses raw log output again, these assertions fail.
+const PLAIN_LOG = "2026-07-15T12:00:00Z [INFO] plugin/reload: config loaded\n";
+
+const mockK8sManager = {} as KubernetesManager;
+
+describe("kubectl_logs tool", () => {
+  const mockedExecFileSync = vi.mocked(execFileSync);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Route kubectl invocations by their argv so a single mock can serve the
+  // multi-step deployment path (get selector -> get pods -> logs per pod).
+  function routeKubectl(returns: {
+    selector?: string;
+    pods?: string;
+    logs?: string;
+  }) {
+    mockedExecFileSync.mockImplementation((_file: any, args: any) => {
+      const argv: string[] = args;
+      if (argv.includes("logs")) return returns.logs ?? PLAIN_LOG;
+      if (argv.includes("get") && argv.includes("pods"))
+        return returns.pods ?? "";
+      if (argv.includes("get")) return returns.selector ?? "";
+      return "";
+    });
+  }
+
+  function allArgs(): string[][] {
+    return mockedExecFileSync.mock.calls.map((c: any) => c[1] as string[]);
+  }
+
+  test("pod path returns plain-text logs verbatim (with explicit container)", async () => {
+    routeKubectl({ logs: PLAIN_LOG });
+
+    const result = await kubectlLogs(mockK8sManager, {
+      resourceType: "pod",
+      name: "coredns-abc",
+      namespace: "kube-system",
+      container: "coredns",
+      tail: 5,
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.name).toBe("coredns-abc");
+    expect(data.logs).toBe(PLAIN_LOG);
+
+    const argv = allArgs()[0];
+    expect(argv).toEqual([
+      "-n",
+      "kube-system",
+      "logs",
+      "coredns-abc",
+      "-c",
+      "coredns",
+      "--tail=5",
+    ]);
+  });
+
+  test("pod path works with no container arg", async () => {
+    routeKubectl({ logs: PLAIN_LOG });
+
+    const result = await kubectlLogs(mockK8sManager, {
+      resourceType: "pod",
+      name: "coredns-abc",
+      namespace: "kube-system",
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.logs).toBe(PLAIN_LOG);
+    expect(allArgs()[0]).not.toContain("-c");
+  });
+
+  // Regression: resourceType omitted must NOT crash on `.toLowerCase()`; it
+  // defaults to "pod" and returns logs.
+  test("defaults to pod when resourceType is omitted (toLowerCase regression)", async () => {
+    routeKubectl({ logs: PLAIN_LOG });
+
+    const result = await kubectlLogs(mockK8sManager, {
+      // resourceType intentionally omitted
+      name: "coredns-abc",
+      namespace: "kube-system",
+      tail: 3,
+    } as any);
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.name).toBe("coredns-abc");
+    expect(data.logs).toBe(PLAIN_LOG);
+    // Took the pod branch: a `logs` invocation happened.
+    expect(allArgs().some((a) => a.includes("logs"))).toBe(true);
+  });
+
+  test("deployment path resolves selector and returns per-pod logs", async () => {
+    routeKubectl({
+      selector: '{"k8s-app":"kube-dns"}',
+      pods: "coredns-1 coredns-2",
+      logs: PLAIN_LOG,
+    });
+
+    const result = await kubectlLogs(mockK8sManager, {
+      resourceType: "deployment",
+      name: "coredns",
+      namespace: "kube-system",
+      tail: 3,
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.selector).toBe("k8s-app=kube-dns");
+    expect(Object.keys(data.logs)).toEqual(["coredns-1", "coredns-2"]);
+    expect(data.logs["coredns-1"]).toBe(PLAIN_LOG);
+    expect(data.logs["coredns-2"]).toBe(PLAIN_LOG);
+  });
+
+  // Regression: the jsonpath argv must not carry literal single quotes, since
+  // there is no shell to strip them under execFileSync.
+  test("jsonpath argv contains no literal single quotes", async () => {
+    routeKubectl({
+      selector: '{"k8s-app":"kube-dns"}',
+      pods: "coredns-1",
+      logs: PLAIN_LOG,
+    });
+
+    await kubectlLogs(mockK8sManager, {
+      resourceType: "deployment",
+      name: "coredns",
+      namespace: "kube-system",
+    });
+
+    const flat = allArgs().flat();
+    expect(flat).toContain("jsonpath={.spec.selector.matchLabels}");
+    for (const tok of flat) {
+      expect(tok).not.toContain("'");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`kubectl_logs` has two independent failure modes on the current release line (reproduced on `v3.9.0`, and the same code is on `main`). Both were surfaced by the move to the shell-less `execFileSyncSafe` wrapper.

The pod path itself works when `resourceType: "pod"` is supplied (single- or multi-container, with or without a `container` arg). The failures are:

### 1. Pod logs with `resourceType` omitted — `Cannot read properties of undefined (reading 'toLowerCase')`

`inputSchema` marks `resourceType` as `required`, but the MCP SDK does not validate arguments against the schema, so a client that omits `resourceType` (easy to do, since a pod name is all you conceptually need) reaches the handler with `undefined` and crashes on `input.resourceType.toLowerCase()`. The error is caught and re-wrapped, producing a confusing doubled `-32603` prefix.

**Fix:** default to `"pod"` — the schema's primary target — instead of dereferencing `undefined`.

### 2. Deployment / job / cronjob logs — `Unexpected non-whitespace character after JSON at position 3`

The selector/pod-name lookups build `-o jsonpath='{...}'` with **literal single quotes**. Those quotes are shell syntax, but `execFileSyncSafe` runs `kubectl` via `execFileSync` (no shell), so kubectl receives them verbatim and prints:

```
'{"k8s-app":"kube-dns"}'
```

The handler then runs `.replace(/'/g, '"')`, yielding `"{"k8s-app":"kube-dns"}"`, and `JSON.parse` rejects it at position 3 (`"{"` parses as a complete string, then `k` is unexpected). This makes every deployment/job/cronjob log fetch fail.

**Fix:** drop the shell-style single quotes from the three `jsonpath=` templates so kubectl emits clean JSON, and remove the now-unnecessary `.replace(/'/g, '"')`.

## Reproduction

```
# works
kubectl_logs { resourceType: "pod", name: "<pod>", namespace: "<ns>" }

# fails: toLowerCase crash (resourceType omitted)
kubectl_logs { name: "<pod>", namespace: "<ns>" }

# fails: JSON.parse at position 3 (workload target)
kubectl_logs { resourceType: "deployment", name: "coredns", namespace: "kube-system" }
```

## Tests

Adds `tests/kubectl-logs.unit.test.ts` (mocks `child_process.execFileSync`, matching the existing `*.unit.test.ts` style):

- pod path returns plain-text logs verbatim, with and without an explicit `container`
- omitted `resourceType` defaults to `pod` (regression for bug 1)
- deployment path resolves the selector and returns per-pod logs (regression for bug 2)
- asserts no kubectl argument contains a literal `'`

## Note

The same shell-style single-quote pattern also affects `kubectl-get.ts` for `output: "custom"` (`-o 'custom-columns=...'`), which kubectl rejects as an unknown output format under `execFileSync`. Out of scope for this PR but worth a follow-up.
