### PR TITLE
Cleanup readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ claude mcp add kubernetes -- npx mcp-server-kubernetes
 
 This will automatically configure the server in your Claude Code MCP settings.
 
+### Codex
+
+Add the MCP server to [Codex CLI](https://developers.openai.com/codex/cli/) using the built-in command:
+
+```bash
+codex mcp add kubernetes -- npx mcp-server-kubernetes
+```
+
+This registers the server globally in `~/.codex/config.toml` and makes its tools available in all Codex sessions.
+
 ### Claude Desktop
 
 Add the following configuration to your Claude Desktop config file:
@@ -121,14 +131,6 @@ Windows:
 
 ```shell
 npx mcp-chat --config "%APPDATA%\Claude\claude_desktop_config.json"
-```
-
-## Gemini CLI
-
-[Gemini CLI](https://geminicli.com/) allows you to install mcp servers as extensions. From a shell, install the extension by pointing to this repo:
-
-```shell
-gemini extensions install https://github.com/Flux159/mcp-server-kubernetes
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -2,16 +2,12 @@
 
 [![CI](https://github.com/Flux159/mcp-server-kubernetes/actions/workflows/ci.yml/badge.svg)](https://github.com/yourusername/mcp-server-kubernetes/actions/workflows/ci.yml)
 [![Language](https://img.shields.io/github/languages/top/Flux159/mcp-server-kubernetes)](https://github.com/yourusername/mcp-server-kubernetes)
-[![Bun](https://img.shields.io/badge/runtime-bun-orange)](https://bun.sh)
 [![Kubernetes](https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=flat&logo=kubernetes&logoColor=white)](https://kubernetes.io/)
 [![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=flat&logo=docker&logoColor=white)](https://www.docker.com/)
 [![Stars](https://img.shields.io/github/stars/Flux159/mcp-server-kubernetes)](https://github.com/Flux159/mcp-server-kubernetes/stargazers)
 [![Issues](https://img.shields.io/github/issues/Flux159/mcp-server-kubernetes)](https://github.com/Flux159/mcp-server-kubernetes/issues)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/Flux159/mcp-server-kubernetes/pulls)
 [![Last Commit](https://img.shields.io/github/last-commit/Flux159/mcp-server-kubernetes)](https://github.com/Flux159/mcp-server-kubernetes/commits/main)
-[![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/Flux159/mcp-server-kubernetes)](https://archestra.ai/mcp-catalog/flux159__mcp-server-kubernetes)
-[![HVTrust](https://hvtracker.net/badge/kubernetes-mcp-server.svg)](https://hvtracker.net/agents/kubernetes-mcp-server/)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Flux159/mcp-server-kubernetes)
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/Flux159/mcp-server-kubernetes/refs/heads/main/icon.png" width="200">
@@ -20,8 +16,6 @@
 MCP Server that can connect to a Kubernetes cluster and manage it. Supports loading kubeconfig from multiple sources in priority order.
 
 https://github.com/user-attachments/assets/f25f8f4e-4d04-479b-9ae0-5dac452dd2ed
-
-<a href="https://glama.ai/mcp/servers/w71ieamqrt"><img width="380" height="200" src="https://glama.ai/mcp/servers/w71ieamqrt/badge" /></a>
 
 ## Installation & Usage
 


### PR DESCRIPTION
Getting badges down to one line and other readme cleanup.

- Remove the bun runtime badge
- Remove the Archestra trust score badge
- Remove the HVTrust badge
- Remove the DeepWiki badge
- Remove the Glama server link
- Remove Gemini CLI install directions (deprecated) and add Codex CLI directions instead — validated end-to-end with `codex mcp add kubernetes -- npx mcp-server-kubernetes` and a live Codex session calling `kubectl_get` against a real cluster
- Install sections ordered: Claude Code, Codex, Claude Desktop, VS Code, Cursor, mcp-chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)