### PR TITLE
Replace star-history.com embed with self-hosted chart via rust-star-history

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,17 @@
+# Regenerates the star-history charts daily and publishes them to the
+# star-history branch. See https://github.com/Flux159/rust-star-history
+name: Star History
+
+on:
+  schedule:
+    - cron: '0 5 * * *' # daily 05:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  star-history:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Flux159/rust-star-history@v0.2.0

--- a/README.md
+++ b/README.md
@@ -425,7 +425,12 @@ Adding clusters to kubectx.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Flux159/mcp-server-kubernetes&type=Date)](https://www.star-history.com/#Flux159/mcp-server-kubernetes&Date)
+<a href="https://github.com/Flux159/rust-star-history">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Flux159/mcp-server-kubernetes/star-history/star-history-dark.svg">
+    <img alt="Star History Chart" src="https://raw.githubusercontent.com/Flux159/mcp-server-kubernetes/star-history/star-history.svg">
+  </picture>
+</a>
 
 ## 🖊️ Cite
 


### PR DESCRIPTION
## Summary

The star-history.com embed in the README stopped rendering for public visitors after GitHub's 2026 stargazers API change. This replaces it with self-hosted charts generated by [Flux159/rust-star-history](https://github.com/Flux159/rust-star-history) v0.2.0:

- `.github/workflows/star-history.yml` runs daily (plus manual dispatch) and force-pushes `star-history.svg` / `star-history-dark.svg` to a dedicated `star-history` branch — no commit noise on main, no PAT needed (the workflow's automatic token + `contents: write` is sufficient)
- The README's Star History section now embeds those SVGs with automatic light/dark theme switching

## After merging

Run the workflow once manually (Actions → Star History → Run workflow) to create the `star-history` branch — the README image 404s until that first run completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)