### PR TITLE
Use rust-star-history v0.2.1 with a PAT for stargazer reads

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -14,4 +14,8 @@ jobs:
   star-history:
     runs-on: ubuntu-latest
     steps:
-      - uses: Flux159/rust-star-history@v0.2.0
+      - uses: Flux159/rust-star-history@v0.2.1
+        with:
+          # The automatic workflow token cannot list stargazers since
+          # GitHub's 2026 API change; this is a read-only fine-grained PAT
+          token: ${{ secrets.STAR_HISTORY_TOKEN }}


### PR DESCRIPTION
Follow-up to #341, whose first run failed with `403: You do not have permission to view the stargazers of this repository` — GitHub's 2026 API change restricts the stargazers list to tokens of users with repo access, which the automatic workflow token is not.

- Pins the action to v0.2.1, which adds exponential-backoff retries for transient failures and a clear error for this permission case
- Passes `token: ${{ secrets.STAR_HISTORY_TOKEN }}` (already configured in this repo's Actions secrets — a read-only fine-grained PAT); the branch push still uses the automatic token

The identical setup was validated end-to-end on Flux159/rust-star-history itself (workflow run succeeded, star-history branch published). After merging, re-run the Star History workflow to create this repo's chart branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)