### PR TITLE
Bump rust-star-history action to v1.0.0

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -14,7 +14,7 @@ jobs:
   star-history:
     runs-on: ubuntu-latest
     steps:
-      - uses: Flux159/rust-star-history@v0.2.1
+      - uses: Flux159/rust-star-history@v1.0.0
         with:
           # The automatic workflow token cannot list stargazers since
           # GitHub's 2026 API change; this is a read-only fine-grained PAT


### PR DESCRIPTION
Bumps the Star History workflow to the 1.0.0 release of [Flux159/rust-star-history](https://github.com/Flux159/rust-star-history) — same behavior as v0.2.1 (which ran successfully here), now stabilized as 1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)