### PR TITLE
Bump rust-star-history action to v1.1.0 for incremental caching

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -14,7 +14,7 @@ jobs:
   star-history:
     runs-on: ubuntu-latest
     steps:
-      - uses: Flux159/rust-star-history@v1.0.0
+      - uses: Flux159/rust-star-history@v1.1.0
         with:
           # The automatic workflow token cannot list stargazers since
           # GitHub's 2026 API change; this is a read-only fine-grained PAT


### PR DESCRIPTION
Bumps the star-history workflow's action pin from v1.0.0 to [v1.1.0](https://github.com/Flux159/rust-star-history/releases/tag/v1.1.0).

v1.1.0 adds incremental caching, enabled by default — no workflow changes needed beyond the version bump. The action now carries stargazer data between runs via `actions/cache`, so the daily refresh asks GitHub for the current star count and fetches only the pages added since the previous run (typically a single API request for this repo) instead of re-downloading all ~15 pages of star history every day. If the cache is evicted (GitHub drops entries unused for ~7 days) the run just refetches in full, and the CLI does a full refresh every 28 days anyway to shed any drift from unstars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)