### PR TITLE
Bump rust-star-history action to v1.1.1

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -14,7 +14,7 @@ jobs:
   star-history:
     runs-on: ubuntu-latest
     steps:
-      - uses: Flux159/rust-star-history@v1.1.0
+      - uses: Flux159/rust-star-history@v1.1.1
         with:
           # The automatic workflow token cannot list stargazers since
           # GitHub's 2026 API change; this is a read-only fine-grained PAT


### PR DESCRIPTION
Bumps the star-history workflow to [rust-star-history v1.1.1](https://github.com/Flux159/rust-star-history/releases/tag/v1.1.1).

The scheduled run failed with `curl: (22) The requested URL returned error: 403` while looking up the prebuilt release asset, then wasted ~2 minutes building from source before failing anyway. v1.1.1 fixes the action to download the binary straight from the release CDN URL (no token, no REST API rate limit) and to fail hard instead of falling back to a source build. See Flux159/rust-star-history#14 for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)