### PR TITLE
Extend remote-transport path-read restrictions to apply, delete, and Helm tools

### DIFF
--- a/src/tools/helm-operations.ts
+++ b/src/tools/helm-operations.ts
@@ -5,9 +5,11 @@
  * Supports local chart paths, remote repositories, and custom values.
  */
 
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { execFileSyncSafe } from "../security/kubectl-flags.js";
 import { writeFileSync, unlinkSync } from "fs";
 import { dump } from "js-yaml";
+import { isRemoteTransport } from "../security/transport.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import {
   contextParameter,
@@ -60,7 +62,8 @@ export const installHelmChartSchema = {
       },
       valuesFile: {
         type: "string",
-        description: "Path to values file (alternative to values object)",
+        description:
+          "Path to values file (alternative to values object). The path is read on the machine running the MCP server, so it is rejected when the server runs over a remote (SSE/Streamable HTTP) transport; use 'values' to pass the values inline instead.",
       },
       useTemplate: {
         type: "boolean",
@@ -116,7 +119,8 @@ export const upgradeHelmChartSchema = {
       },
       valuesFile: {
         type: "string",
-        description: "Path to values file (alternative to values object)",
+        description:
+          "Path to values file (alternative to values object). The path is read on the machine running the MCP server, so it is rejected when the server runs over a remote (SSE/Streamable HTTP) transport; use 'values' to pass the values inline instead.",
       },
     },
     required: ["name", "chart", "namespace"],
@@ -168,6 +172,21 @@ const executeCommand = (command: string, args: string[]): string => {
   }
 };
 
+// Reject server-side filesystem reads on remote transports. Over SSE /
+// Streamable HTTP the path resolves on the MCP server host, not the client,
+// so `valuesFile` (-f) would let any client that can reach the endpoint read
+// arbitrary server files (kubeconfig, service-account token,
+// /proc/self/environ, etc.) via helm's parse errors. Clients on these
+// transports must pass values inline via `values` instead.
+const rejectValuesFileOnRemoteTransport = (valuesFile?: string): void => {
+  if (valuesFile && isRemoteTransport()) {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      "The 'valuesFile' parameter reads a file from the MCP server's filesystem and is disabled on remote (SSE/Streamable HTTP) transports. Pass the values inline via 'values' instead."
+    );
+  }
+};
+
 /**
  * Install a Helm chart using template mode (helm template + kubectl apply).
  * This mode bypasses authentication issues and kubeconfig API version mismatches.
@@ -203,17 +222,7 @@ async function installHelmChartTemplate(params: {
       steps.push(`Namespace ${params.namespace} already exists`);
     }
 
-    // Step 3: Prepare values
-    let valuesContent = "";
-    if (params.valuesFile) {
-      steps.push(`Using values file: ${params.valuesFile}`);
-      valuesContent = executeCommand("cat", [params.valuesFile]);
-    } else if (params.values) {
-      steps.push("Using provided values object");
-      valuesContent = dump(params.values);
-    }
-
-    // Step 4: Generate YAML using helm template
+    // Step 3: Generate YAML using helm template
     steps.push("Generating YAML using helm template");
     const templateArgs = [
       "template",
@@ -227,43 +236,40 @@ async function installHelmChartTemplate(params: {
       templateArgs.push("--repo", params.repo);
     }
 
-    if (valuesContent) {
-      const tempValuesFile = `/tmp/values-${Date.now()}.yaml`;
-      writeFileSync(tempValuesFile, valuesContent);
+    let tempValuesFile: string | null = null;
+    if (params.valuesFile) {
+      // Hand the path to helm directly rather than reading the file's
+      // contents into this process.
+      steps.push(`Using values file: ${params.valuesFile}`);
+      templateArgs.push("-f", params.valuesFile);
+    } else if (params.values) {
+      steps.push("Using provided values object");
+      tempValuesFile = `/tmp/values-${Date.now()}.yaml`;
+      writeFileSync(tempValuesFile, dump(params.values));
       templateArgs.push("-f", tempValuesFile);
+    }
 
-      const yamlOutput = executeCommand("helm", templateArgs);
-
+    let yamlOutput: string;
+    try {
+      yamlOutput = executeCommand("helm", templateArgs);
+    } finally {
       // Clean up temp file
-      unlinkSync(tempValuesFile);
-
-      // Step 5: Apply YAML using kubectl
-      steps.push("Applying YAML using kubectl");
-      const tempYamlFile = `/tmp/helm-template-${Date.now()}.yaml`;
-      writeFileSync(tempYamlFile, yamlOutput);
-
-      try {
-        executeCommand("kubectl", ["apply", "-f", tempYamlFile]);
-        steps.push("Helm chart installed successfully using template mode");
-      } finally {
-        // Clean up temp file
-        unlinkSync(tempYamlFile);
+      if (tempValuesFile) {
+        unlinkSync(tempValuesFile);
       }
-    } else {
-      const yamlOutput = executeCommand("helm", templateArgs);
+    }
 
-      // Step 5: Apply YAML using kubectl
-      steps.push("Applying YAML using kubectl");
-      const tempYamlFile = `/tmp/helm-template-${Date.now()}.yaml`;
-      writeFileSync(tempYamlFile, yamlOutput);
+    // Step 4: Apply YAML using kubectl
+    steps.push("Applying YAML using kubectl");
+    const tempYamlFile = `/tmp/helm-template-${Date.now()}.yaml`;
+    writeFileSync(tempYamlFile, yamlOutput);
 
-      try {
-        executeCommand("kubectl", ["apply", "-f", tempYamlFile]);
-        steps.push("Helm chart installed successfully using template mode");
-      } finally {
-        // Clean up temp file
-        unlinkSync(tempYamlFile);
-      }
+    try {
+      executeCommand("kubectl", ["apply", "-f", tempYamlFile]);
+      steps.push("Helm chart installed successfully using template mode");
+    } finally {
+      // Clean up temp file
+      unlinkSync(tempYamlFile);
     }
 
     return {
@@ -302,6 +308,8 @@ async function installHelmChartTemplate(params: {
 export async function installHelmChart(
   params: HelmInstallOperation
 ): Promise<{ content: { type: string; text: string }[] }> {
+  rejectValuesFileOnRemoteTransport(params.valuesFile);
+
   // Use template mode if requested
   if (params.useTemplate) {
     return installHelmChartTemplate(params);
@@ -383,6 +391,8 @@ export async function installHelmChart(
 export async function upgradeHelmChart(
   params: HelmUpgradeOperation
 ): Promise<{ content: { type: string; text: string }[] }> {
+  rejectValuesFileOnRemoteTransport(params.valuesFile);
+
   try {
     // Add repository if provided
     if (params.repo) {

--- a/src/tools/kubectl-apply.ts
+++ b/src/tools/kubectl-apply.ts
@@ -6,6 +6,7 @@ import * as path from "path";
 import * as os from "os";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import { contextParameter, namespaceParameter, dryRunParameter } from "../models/common-parameters.js";
+import { isRemoteTransport } from "../security/transport.js";
 
 export const kubectlApplySchema = {
   name: "kubectl_apply",
@@ -23,7 +24,7 @@ export const kubectlApplySchema = {
       filename: {
         type: "string",
         description:
-          "Path to a YAML file to apply (optional - use either manifest or filename)",
+          "Path to a YAML file to apply (optional - use either manifest or filename). The path is read on the machine running the MCP server, so it is rejected when the server runs over a remote (SSE/Streamable HTTP) transport; use 'manifest' to pass the file's contents instead.",
       },
       namespace: namespaceParameter,
       dryRun: dryRunParameter,
@@ -55,6 +56,19 @@ export async function kubectlApply(
       throw new McpError(
         ErrorCode.InvalidRequest,
         "Either manifest or filename must be provided"
+      );
+    }
+
+    // Reject server-side filesystem reads on remote transports. Over SSE /
+    // Streamable HTTP the path resolves on the MCP server host, not the
+    // client, so `filename` (-f) would let any client that can reach the
+    // endpoint read arbitrary server files (kubeconfig, service-account
+    // token, /proc/self/environ, etc.) via kubectl's parse errors. Clients
+    // on these transports must pass content inline via `manifest` instead.
+    if (isRemoteTransport() && input.filename) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        "The 'filename' parameter reads a file from the MCP server's filesystem and is disabled on remote (SSE/Streamable HTTP) transports. Pass the file contents via 'manifest' instead."
       );
     }
 

--- a/src/tools/kubectl-delete.ts
+++ b/src/tools/kubectl-delete.ts
@@ -9,6 +9,7 @@ import {
   contextParameter,
   namespaceParameter,
 } from "../models/common-parameters.js";
+import { isRemoteTransport } from "../security/transport.js";
 
 export const kubectlDeleteSchema = {
   name: "kubectl_delete",
@@ -41,7 +42,8 @@ export const kubectlDeleteSchema = {
       },
       filename: {
         type: "string",
-        description: "Path to a YAML file to delete resources from (optional)",
+        description:
+          "Path to a YAML file to delete resources from (optional). The path is read on the machine running the MCP server, so it is rejected when the server runs over a remote (SSE/Streamable HTTP) transport; use 'manifest' to pass the file's contents instead.",
       },
       allNamespaces: {
         type: "boolean",
@@ -94,6 +96,19 @@ export async function kubectlDelete(
       throw new McpError(
         ErrorCode.InvalidRequest,
         "When using resourceType, either name or labelSelector must be provided"
+      );
+    }
+
+    // Reject server-side filesystem reads on remote transports. Over SSE /
+    // Streamable HTTP the path resolves on the MCP server host, not the
+    // client, so `filename` (-f) would let any client that can reach the
+    // endpoint read arbitrary server files (kubeconfig, service-account
+    // token, /proc/self/environ, etc.) via kubectl's parse errors. Clients
+    // on these transports must pass content inline via `manifest` instead.
+    if (isRemoteTransport() && input.filename) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        "The 'filename' parameter reads a file from the MCP server's filesystem and is disabled on remote (SSE/Streamable HTTP) transports. Pass the file contents via 'manifest' instead."
       );
     }
 

--- a/tests/remote-transport-path-reads.unit.test.ts
+++ b/tests/remote-transport-path-reads.unit.test.ts
@@ -1,0 +1,100 @@
+import { expect, test, describe, beforeEach, afterEach } from "vitest";
+import { kubectlApply } from "../src/tools/kubectl-apply.js";
+import { kubectlDelete } from "../src/tools/kubectl-delete.js";
+import {
+  installHelmChart,
+  upgradeHelmChart,
+} from "../src/tools/helm-operations.js";
+
+// On remote (SSE / Streamable HTTP) transports, server-side path params
+// resolve on the MCP server host rather than the client's machine, so any
+// client that can reach the endpoint could read arbitrary server files.
+// These params must be rejected before the child process runs, steering
+// clients to the inline-content params (`manifest`, `values`) which are safe
+// on all transports. This mirrors the existing kubectl_create guard (see
+// tests/kubectl-create-from-file.unit.test.ts).
+
+const TRANSPORT_ENV = [
+  "ENABLE_UNSAFE_SSE_TRANSPORT",
+  "ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT",
+] as const;
+
+// The guards run before any kubectl/helm execution, so a stub manager is fine.
+const manager = {} as any;
+
+describe("server-side path params are rejected on remote transports", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    TRANSPORT_ENV.forEach((k) => {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    });
+  });
+
+  afterEach(() => {
+    TRANSPORT_ENV.forEach((k) => {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    });
+  });
+
+  for (const envVar of TRANSPORT_ENV) {
+    test(`kubectl_apply rejects filename under ${envVar}`, async () => {
+      process.env[envVar] = "true";
+      await expect(
+        kubectlApply(manager, {
+          filename: "/etc/passwd",
+          dryRun: true,
+        })
+      ).rejects.toThrow(/'filename'.*disabled on remote/s);
+    });
+
+    test(`kubectl_delete rejects filename under ${envVar}`, async () => {
+      process.env[envVar] = "true";
+      await expect(
+        kubectlDelete(manager, {
+          filename: "/etc/passwd",
+        })
+      ).rejects.toThrow(/'filename'.*disabled on remote/s);
+    });
+
+    test(`install_helm_chart rejects valuesFile under ${envVar}`, async () => {
+      process.env[envVar] = "true";
+      await expect(
+        installHelmChart({
+          name: "leak",
+          chart: "nginx",
+          namespace: "default",
+          valuesFile: "/etc/passwd",
+        })
+      ).rejects.toThrow(/'valuesFile'.*disabled on remote/s);
+    });
+
+    test(`install_helm_chart rejects valuesFile in template mode under ${envVar}`, async () => {
+      process.env[envVar] = "true";
+      await expect(
+        installHelmChart({
+          name: "leak",
+          chart: "nginx",
+          namespace: "default",
+          useTemplate: true,
+          valuesFile: "/etc/passwd",
+        })
+      ).rejects.toThrow(/'valuesFile'.*disabled on remote/s);
+    });
+
+    test(`upgrade_helm_chart rejects valuesFile under ${envVar}`, async () => {
+      process.env[envVar] = "true";
+      await expect(
+        upgradeHelmChart({
+          name: "leak",
+          chart: "nginx",
+          namespace: "default",
+          valuesFile: "/etc/passwd",
+        })
+      ).rejects.toThrow(/'valuesFile'.*disabled on remote/s);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

#332 restricted server-side filesystem path parameters (`filename`, `fromFile`) for `kubectl_create` when the server runs over a remote (SSE / Streamable HTTP) transport, since those paths resolve on the machine running the MCP server rather than the client's machine. This PR applies the same rule consistently to the remaining tools that accept a server-side path:

- `kubectl_apply`: `filename` (`-f`)
- `kubectl_delete`: `filename` (`-f`)
- `install_helm_chart` / `upgrade_helm_chart`: `valuesFile` (`-f`), in both standard and template mode

Each parameter is now rejected on remote transports (via the existing `isRemoteTransport()` helper from `src/security/transport.ts`) with an error steering the client to the inline equivalent (`manifest` for kubectl, `values` for Helm), which works on all transports. stdio behavior is unchanged. Tool schema descriptions are updated to document the restriction.

Also simplifies Helm template mode: `valuesFile` is now passed straight to `helm template -f` instead of being read into the process via `cat`, and the duplicated template/apply branches are collapsed into one path.

## Testing

- `bun run build` passes
- New unit tests in `tests/remote-transport-path-reads.unit.test.ts` cover the guard for all four tools under both transport env vars (10 tests); existing `tests/kubectl-create-from-file.unit.test.ts` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)