### PR TITLE
Harden dangerous-flag guard against attached short-flag form

### DIFF
--- a/src/security/kubectl-flags.ts
+++ b/src/security/kubectl-flags.ts
@@ -87,12 +87,31 @@ function normalizeFlagName(raw: string): string {
   return name.toLowerCase();
 }
 
+// Extract the short-flag letter from a single-dash token, or null if the token
+// is not a single-dash short flag. pflag lets a short flag carry its value
+// attached with no separator ("-shttp://x" == "--server http://x"), so the
+// letter that matters is always the first character after the dash; the rest of
+// the token is the attached value (or a boolean-flag cluster). Long "--" flags
+// never attach a value without "=", so normalizeFlagName already handles them.
+function shortFlagLetter(raw: string): string | null {
+  if (!raw.startsWith("-") || raw.startsWith("--")) return null;
+  const body = raw.slice(1);
+  if (body.length === 0) return null;
+  return body[0].toLowerCase();
+}
+
 function isDangerousFlagName(rawName: string, fromArgs: boolean): boolean {
   const name = normalizeFlagName(rawName);
   if (DANGEROUS_FLAGS.has(name)) return true;
   // Short aliases (-s) are only meaningful when they appear as a CLI token,
-  // not as a key in the `flags` object.
-  if (fromArgs && SHORT_ALIASES.has(name)) return true;
+  // not as a key in the `flags` object. Match both the bare/split forms
+  // (normalizeFlagName -> "s") and the attached form "-sURL" (whose first
+  // post-dash character is the flag pflag actually parses).
+  if (fromArgs) {
+    if (SHORT_ALIASES.has(name)) return true;
+    const short = shortFlagLetter(rawName);
+    if (short !== null && SHORT_ALIASES.has(short)) return true;
+  }
   return false;
 }
 
@@ -156,6 +175,10 @@ export function assertSafeArgv(args: readonly string[]): void {
     if (!tok.startsWith("-")) continue;
     const name = normalizeFlagName(tok);
     if (ARGV_DANGEROUS_FLAGS.has(name) || SHORT_ALIASES.has(name)) reject(tok);
+    // Attached short-flag form ("-sURL"): match the first post-dash character,
+    // which is the flag pflag parses regardless of the trailing value.
+    const short = shortFlagLetter(tok);
+    if (short !== null && SHORT_ALIASES.has(short)) reject(tok);
   }
 }
 

--- a/tests/kubectl-flags-security.unit.test.ts
+++ b/tests/kubectl-flags-security.unit.test.ts
@@ -101,6 +101,25 @@ describe("assertNoDangerousFlags", () => {
       ).toThrow(/-s/);
     });
 
+    test("rejects attached short-flag form '-sURL' (no separator)", () => {
+      // pflag parses "-shttp://attacker" as "--server http://attacker".
+      expect(() =>
+        assertNoDangerousFlags(undefined, ["-shttp://attacker.example.com"])
+      ).toThrow(McpError);
+    });
+
+    test("rejects attached short-flag form '-s=URL'", () => {
+      expect(() =>
+        assertNoDangerousFlags(undefined, ["-s=https://attacker"])
+      ).toThrow(McpError);
+    });
+
+    test("does not flag benign short flags with attached values (-oyaml)", () => {
+      expect(() =>
+        assertNoDangerousFlags(undefined, ["-oyaml"])
+      ).not.toThrow();
+    });
+
     test("rejects --insecure-skip-tls-verify=true in args", () => {
       expect(() =>
         assertNoDangerousFlags(undefined, ["--insecure-skip-tls-verify=true"])
@@ -193,6 +212,16 @@ describe("kubectl_generic refuses dangerous flags before executing kubectl", () 
     ).rejects.toThrow(/--server/);
   });
 
+  test("blocks attached short-flag form '-sURL' smuggled through args", async () => {
+    await expect(
+      kubectlGeneric(stubManager, {
+        command: "get",
+        resourceType: "pods",
+        args: ["-shttp://attacker.example.com"],
+      })
+    ).rejects.toThrow(McpError);
+  });
+
   test("error code is InvalidParams (not InternalError)", async () => {
     try {
       await kubectlGeneric(stubManager, {
@@ -235,6 +264,15 @@ describe("assertSafeArgv (full-argv guard for positional slots)", () => {
     );
     expect(() => assertSafeArgv(["get", "--token=stolen"])).toThrow(/--token/);
     expect(() => assertSafeArgv(["get", "-s", "https://attacker"])).toThrow(/-s/);
+  });
+
+  test("rejects attached short-flag form '-sURL' in argv", () => {
+    expect(() =>
+      assertSafeArgv(["get", "pods", "-shttp://attacker.example.com"])
+    ).toThrow(McpError);
+    expect(() =>
+      assertSafeArgv(["get", "pods", "-s=https://attacker"])
+    ).toThrow(McpError);
   });
 
   test("rejects helm credential/target flags (kube-* prefix)", () => {


### PR DESCRIPTION
## Summary

The argv-level dangerous-flag guard in `src/security/kubectl-flags.ts` normalizes flag tokens by stripping leading dashes and an `=value` suffix, but it did not separate a single-dash short flag from a value attached with no separator. A token such as `-sURL` normalized to `surl`, matching neither the denylist nor the short-alias set, so it passed the guard — even though the kubectl/helm pflag parser treats `-sURL` identically to the already-blocked `--server URL`, `-s URL`, and `-s=URL` forms.

## Change

- Add `shortFlagLetter()` to extract the first post-dash character of a single-dash token (the flag the parser actually binds when a value is attached).
- Check it against `SHORT_ALIASES` in both `isDangerousFlagName` (args path) and `assertSafeArgv`.
- Long `--` flags are unaffected (they require `=` to attach a value, already handled by `normalizeFlagName`). Benign short flags with attached values such as `-oyaml` are unaffected.

## Tests

Added regression tests for the attached short-flag form (`-sURL` and `-s=URL`) across `assertNoDangerousFlags`, `assertSafeArgv`, and the `kubectl_generic` args path, plus a negative test confirming `-oyaml` still passes. All 38 tests in the security suite pass; build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)