### PR TITLE
Add security.mcpAuthToken to Helm chart and warn when http/sse runs unauthenticated

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -419,6 +419,16 @@ docker run --rm -it -p 3001:3001 \
   flux159/mcp-server-kubernetes:latest
 ```
 
+Or with the Helm chart (which defaults to `http` transport): set
+`security.mcpAuthToken` — the chart stores it in a Secret and wires it in as
+`MCP_AUTH_TOKEN`. If it is left empty with `http`/`sse` transport, the install
+prints a warning that the endpoint is unauthenticated.
+
+```shell
+helm install mcp-server-k8s ./helm-chart \
+  --set security.mcpAuthToken=$(openssl rand -hex 32)
+```
+
 #### Client Configuration
 
 **Codex CLI (toml):**

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -153,6 +153,35 @@ helm install mcp-server-k8s ./helm-chart \
 
 ## Security Configuration
 
+### HTTP/SSE Transport Authentication (Recommended)
+
+This chart defaults to `transport.mode: "http"`, which exposes the MCP endpoint
+over the network. With no token configured, the server accepts **unauthenticated**
+requests from any client that can reach the Service and runs them against your
+cluster with the deployment's RBAC permissions.
+
+Whenever you run with `http` or `sse` transport, set `security.mcpAuthToken` to a
+high-entropy value. The chart stores it in a Secret and the server then requires
+every request to carry a matching `X-MCP-AUTH: <token>` header:
+
+```bash
+helm install mcp-server-k8s ./helm-chart \
+  --set security.mcpAuthToken=$(openssl rand -hex 32)
+```
+
+Or in a values file (keep the token out of source control — use `--set`, a
+sealed secret, or an external secrets manager):
+
+```yaml
+security:
+  mcpAuthToken: "your-high-entropy-token"
+```
+
+If you leave `security.mcpAuthToken` empty with `http`/`sse` transport, `helm
+install`/`upgrade` prints a warning, and you should instead front the server with
+your own authenticating proxy and restrict access with a NetworkPolicy (see
+below). The token has no effect in `stdio` mode.
+
 ### Non-Destructive Mode (Safe Operations Only)
 
 ```bash
@@ -370,6 +399,7 @@ helm schema validate ./helm-chart/values.yaml ./helm-chart/values.schema.json
 | `security.allowOnlyNonDestructive` | bool | `false` | Disable destructive operations (kubectl_delete, uninstall_helm_chart, cleanup, kubectl_generic) |
 | `security.allowOnlyReadonly` | bool | `false` | Enable read-only mode (kubectl_get, kubectl_describe, kubectl_logs, kubectl_context, explain_resource, list_api_resources, ping) |
 | `security.allowedTools` | string | `""` | Comma-separated list of specific tools to allow |
+| `security.mcpAuthToken` | string | `""` | Token required in the `X-MCP-AUTH` header for `http`/`sse` transports. Strongly recommended; stored in a Secret. Empty means the endpoint is unauthenticated. |
 
 ### Scaling and Resources
 

--- a/helm-chart/templates/NOTES.txt
+++ b/helm-chart/templates/NOTES.txt
@@ -71,6 +71,27 @@
 
 {{- end }}
 
+{{- if and (or (eq .Values.transport.mode "http") (eq .Values.transport.mode "sse")) (not .Values.security.mcpAuthToken) }}
+
+   ############################################################################
+   #  WARNING: {{ upper .Values.transport.mode }} transport is enabled WITHOUT authentication.
+   #
+   #  The MCP endpoint accepts UNAUTHENTICATED requests from any client that can
+   #  reach the Service, and those requests run against your cluster with this
+   #  deployment's RBAC permissions (read Secrets, exec into Pods, etc.).
+   #
+   #  Set a high-entropy token and upgrade:
+   #    helm upgrade {{ .Release.Name }} <chart> \
+   #      --set security.mcpAuthToken=$(openssl rand -hex 32)
+   #
+   #  Clients must then send the header:  X-MCP-AUTH: <token>
+   #
+   #  Only leave this unset if you front the server with your own authenticating
+   #  proxy. Consider also restricting access with a NetworkPolicy
+   #  (networkPolicy.enabled=true).
+   ############################################################################
+{{- end }}
+
 2. Configuration Summary:
 
    Kubeconfig Provider: {{ .Values.kubeconfig.provider }}
@@ -109,6 +130,13 @@
    {{- end }}
    {{- if not (or .Values.security.allowOnlyNonDestructive .Values.security.allowOnlyReadonly .Values.security.allowedTools) }}
    - All tools enabled (full access)
+   {{- end }}
+   {{- if or (eq .Values.transport.mode "http") (eq .Values.transport.mode "sse") }}
+   {{- if .Values.security.mcpAuthToken }}
+   - HTTP auth (X-MCP-AUTH): ENABLED
+   {{- else }}
+   - HTTP auth (X-MCP-AUTH): DISABLED (set security.mcpAuthToken to require a token)
+   {{- end }}
    {{- end }}
 
 3. Verify deployment:

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -127,7 +127,14 @@ spec:
             - name: ALLOWED_TOOLS
               value: {{ .Values.security.allowedTools | quote }}
             {{- end }}
-            
+            {{- if .Values.security.mcpAuthToken }}
+            - name: MCP_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-server-kubernetes.fullname" . }}-auth
+                  key: mcp-auth-token
+            {{- end }}
+
             # Kubeconfig configuration
             {{- if eq (include "mcp-server-kubernetes.needsKubeconfigVolume" .) "true" }}
             {{- $kubeconfigPath := include "mcp-server-kubernetes.kubeconfigEnv" . }}

--- a/helm-chart/templates/secret-auth.yaml
+++ b/helm-chart/templates/secret-auth.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.security.mcpAuthToken }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mcp-server-kubernetes.fullname" . }}-auth
+  labels:
+    {{- include "mcp-server-kubernetes.labels" . | nindent 4 }}
+  {{- $commonAnnotations := include "mcp-server-kubernetes.annotations" . }}
+  {{- if $commonAnnotations }}
+  annotations:
+    {{- $commonAnnotations | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  mcp-auth-token: {{ .Values.security.mcpAuthToken | quote }}
+{{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -199,7 +199,18 @@ security:
   # kubectl_generic, kubectl_context, install_helm_chart, upgrade_helm_chart,
   # uninstall_helm_chart, start_port_forward, stop_port_forward, exec_in_pod,
   # explain_resource, list_api_resources, ping, cleanup
-  
+
+  # HTTP/SSE transport authentication (X-MCP-AUTH header).
+  # STRONGLY RECOMMENDED whenever transport.mode is "http" or "sse": those modes
+  # expose the MCP endpoint over the network, and with no token set the server
+  # accepts unauthenticated requests from ANY client that can reach the Service
+  # and runs them against your cluster with this deployment's RBAC. Set a
+  # high-entropy token here; the chart stores it in a Secret and the server then
+  # requires clients to send a matching "X-MCP-AUTH: <token>" header. Leave empty
+  # only if you front the server with your own authenticating proxy. No effect in
+  # stdio mode.
+  mcpAuthToken: ""
+
   # Pod security context
   podSecurityContext:
     fsGroup: 1000


### PR DESCRIPTION
## Summary

The Helm chart defaults to `transport.mode: "http"`, which exposes the MCP endpoint over the network, but there was no first-class way to enable the built-in `X-MCP-AUTH` authentication from the chart, and a default install gave no signal that the endpoint was unauthenticated. This makes the recommended-secure path easy to opt into and loud when it's missing.

## Changes

- **`security.mcpAuthToken` value** — when set, the chart creates an Opaque Secret (`<release>-auth`) holding the token and wires it into the server container as `MCP_AUTH_TOKEN` via `secretKeyRef` (keeps it out of the Deployment spec in plaintext). No effect in `stdio` mode.
- **Install/upgrade warning** — `NOTES.txt` prints a prominent warning when transport is `http`/`sse` and no token is set, with the exact `--set security.mcpAuthToken=$(openssl rand -hex 32)` remediation, and the config summary now shows `HTTP auth (X-MCP-AUTH): ENABLED/DISABLED`.
- **Docs** — chart README gains an "HTTP/SSE Transport Authentication (Recommended)" section and a values-table row; `values.yaml` comment and `ADVANCED_README.md` recommend the setting for Helm users.

## Testing

`helm lint` passes. Rendered and verified:
- **http, no token** → no `MCP_AUTH_TOKEN`, no Secret, warning shown.
- **http/sse, with token** → Secret created with the token, env wired via `secretKeyRef`, summary shows ENABLED.
- **stdio** → no warning, no auth env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)