### PR TITLE
fix(exec_in_pod): return stdout+stderr+exit code on non-zero exit instead of discarding output

### DIFF
--- a/src/tools/exec_in_pod.ts
+++ b/src/tools/exec_in_pod.ts
@@ -139,6 +139,30 @@ export async function execInPod(
       );
     }
 
+    // A non-zero exit code from the command inside the pod is a NORMAL outcome of
+    // running commands, not an internal tool error. Throwing here discards stdout
+    // entirely (execFileSync attaches it to the error object), which loses all
+    // partial output — e.g. a diagnostic command that prints 20 useful lines and
+    // then exits 1 previously returned only "command terminated with exit code 1".
+    // Return stdout + stderr + the exit code instead, so callers see everything
+    // the command produced. Genuine spawn/infra failures (kubectl missing, RBAC,
+    // connection refused) have no exit status and still throw below.
+    if (typeof error.status === "number") {
+      const stdout = (error.stdout ?? "").toString();
+      const stderr = (error.stderr ?? "").toString();
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Command exited with code ${error.status}\n` +
+              (stdout ? `--- stdout ---\n${stdout}\n` : "") +
+              (stderr ? `--- stderr ---\n${stderr}` : ""),
+          },
+        ],
+      };
+    }
+
     throw new McpError(
       ErrorCode.InternalError,
       `Failed to execute command in pod: ${error.stderr || error.message}`


### PR DESCRIPTION
## Problem

When the command executed inside the pod exits non-zero, `exec_in_pod` throws `McpError` with only `error.stderr || error.message` — **stdout is discarded entirely**. `execFileSync` attaches the captured stdout/stderr to the thrown error object, but the catch block never surfaces it.

Practical impact for agent callers: a diagnostic command that prints many useful lines and then exits 1 (e.g. a probe whose non-zero exit is itself the signal) returns nothing but `Failed to execute command in pod: command terminated with exit code 1`. All partial output is lost, and the caller can't distinguish "command ran and failed" from "tool broke".

## Fix

A non-zero exit code from the in-pod command is a *normal outcome of running commands*, not an internal tool error. When the caught error carries a numeric `status` (i.e. the process ran and exited), return a normal tool result containing the exit code + captured stdout + stderr:

```
Command exited with code 1
--- stdout ---
useful-line-1
useful-line-2
--- stderr ---
err-line
```

Genuine spawn/infra failures (kubectl missing, RBAC, connection refused — no exit status) and timeouts keep their existing throw behavior.

## Testing

Verified against a live cluster: `execInPod` with `['bash','-c','echo useful-line-1; echo useful-line-2; echo err-line >&2; exit 1']` now returns the full output block above; a successful command returns unchanged; a timeout still throws the timeout McpError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)