### PR TITLE
Add DNS rebinding protection to SSE transport

### DIFF
--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -3,18 +3,75 @@ import express from "express";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { createAuthMiddleware, isAuthEnabled } from "./auth.js";
 
+/**
+ * Build the default allowedHosts list for DNS rebinding protection.
+ * Includes localhost variants with and without port.
+ */
+function buildDefaultAllowedHosts(host: string, port: number): string[] {
+  // Always allow the bare host and host:port for common localhost addresses
+  const localhostAliases = ["127.0.0.1", "localhost", "::1"];
+  const hosts: string[] = [];
+  for (const alias of localhostAliases) {
+    hosts.push(alias);
+    // HTTP Host header uses bracket notation for IPv6: [::1]:3000
+    if (alias.includes(":")) {
+      hosts.push(`[${alias}]`);
+      hosts.push(`[${alias}]:${port}`);
+    } else {
+      hosts.push(`${alias}:${port}`);
+    }
+  }
+  // Also add the configured host if it's not already covered
+  if (!localhostAliases.includes(host)) {
+    hosts.push(host);
+    if (host.includes(":") && !host.startsWith("[")) {
+      hosts.push(`[${host}]`);
+      hosts.push(`[${host}]:${port}`);
+    } else {
+      hosts.push(`${host}:${port}`);
+    }
+  }
+  return hosts;
+}
+
 export function startSSEServer(server: Server) {
   const app = express();
 
   // Create auth middleware - when MCP_AUTH_TOKEN is set, requires X-MCP-AUTH header
   const authMiddleware = createAuthMiddleware();
 
+  // DNS rebinding protection is enabled by default. Set DNS_REBINDING_PROTECTION=false to disable.
+  const enableDnsRebindingProtection =
+    process.env.DNS_REBINDING_PROTECTION !== "false";
+
+  const host = process.env.HOST || "localhost";
+
+  const parsed = parseInt(process.env.PORT || "3000", 10);
+  const port = Number.isNaN(parsed) ? 3000 : parsed;
+
+  const allowedHosts = process.env.DNS_REBINDING_ALLOWED_HOST
+    ? [process.env.DNS_REBINDING_ALLOWED_HOST]
+    : buildDefaultAllowedHosts(host, port);
+
+  // Warn when binding to all interfaces with DNS rebinding protection disabled
+  if (!enableDnsRebindingProtection && (host === "0.0.0.0" || host === "::")) {
+    console.warn(
+      "WARNING: DNS rebinding protection is disabled while HOST is set to " +
+        `'${host}'. This exposes the MCP server to DNS rebinding attacks ` +
+        "from any browser on the network. Set DNS_REBINDING_PROTECTION=true " +
+        "(the default) or restrict HOST to 'localhost' / '127.0.0.1'."
+    );
+  }
+
   // Currently just copying from docs & allowing for multiple transport connections: https://modelcontextprotocol.io/docs/concepts/transports#server-sent-events-sse
   // Note: When MCP_AUTH_TOKEN is set, requests require X-MCP-AUTH header for authentication
   let transports: Array<SSEServerTransport> = [];
 
   app.get("/sse", authMiddleware, async (req, res) => {
-    const transport = new SSEServerTransport("/messages", res);
+    const transport = new SSEServerTransport("/messages", res, {
+      enableDnsRebindingProtection,
+      allowedHosts,
+    });
     transports.push(transport);
     await server.connect(transport);
   });
@@ -55,16 +112,6 @@ export function startSSEServer(server: Server) {
     }
   });
 
-  let port = 3000;
-  try {
-    port = parseInt(process.env.PORT || "3000", 10);
-  } catch (e) {
-    console.error(
-      "Invalid PORT environment variable, using default port 3000."
-    );
-  }
-
-  const host = process.env.HOST || "localhost";
   app.listen(port, host, () => {
     console.log(
       `mcp-kubernetes-server is listening on port ${port}\nUse the following url to connect to the server:\nhttp://${host}:${port}/sse`


### PR DESCRIPTION
## Summary

The SSE transport was not passing DNS rebinding protection options to the `SSEServerTransport` constructor, leaving it unprotected when bound to all network interfaces. The streamable HTTP transport already had this protection — this change brings the same safeguard to SSE.

## Changes

- **`src/utils/sse.ts`** — add `buildDefaultAllowedHosts()` helper (same logic used by `streamable-http.ts`), read the `DNS_REBINDING_PROTECTION` and `DNS_REBINDING_ALLOWED_HOST` environment variables, and pass both `enableDnsRebindingProtection` and `allowedHosts` to the `SSEServerTransport` constructor.
- Add warning on startup when protection is disabled and `HOST` is `0.0.0.0` or `::`.
- Port/host resolution moved before the route definitions (needed for the allowed hosts list).

## Testing

`bun run build` passes cleanly.