### PR TITLE
Extend remote-transport path-read restriction to kubectl_patch

### DIFF
--- a/src/tools/kubectl-patch.ts
+++ b/src/tools/kubectl-patch.ts
@@ -1,5 +1,6 @@
 import { KubernetesManager } from "../types.js";
 import { execFileSyncSafe } from "../security/kubectl-flags.js";
+import { isRemoteTransport } from "../security/transport.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import * as fs from "fs";
 import * as path from "path";
@@ -44,7 +45,7 @@ export const kubectlPatchSchema = {
       patchFile: {
         type: "string",
         description:
-          "Path to a file containing the patch data (alternative to patchData)",
+          "Path to a file containing the patch data (alternative to patchData). The path is read on the machine running the MCP server, so it is rejected when the server runs over a remote (SSE/Streamable HTTP) transport; use 'patchData' to pass the patch contents instead.",
       },
       dryRun: dryRunParameter,
       context: contextParameter,
@@ -71,6 +72,21 @@ export async function kubectlPatch(
       throw new McpError(
         ErrorCode.InvalidRequest,
         "Either patchData or patchFile must be provided"
+      );
+    }
+
+    // Reject server-side filesystem reads on remote transports. Over SSE /
+    // Streamable HTTP the path resolves on the MCP server host, not the
+    // client, so `patchFile` (--patch-file) would let any client that can
+    // reach the endpoint read arbitrary server files (kubeconfig,
+    // service-account token, /proc/self/environ, etc.) via kubectl's parse
+    // errors, or merge their contents into a resource that is then readable
+    // through kubectl_get. Clients on these transports must pass the patch
+    // inline via `patchData` instead.
+    if (isRemoteTransport() && input.patchFile) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        "The 'patchFile' parameter reads a file from the MCP server's filesystem and is disabled on remote (SSE/Streamable HTTP) transports. Pass the patch contents via 'patchData' instead."
       );
     }
 

--- a/tests/remote-transport-path-reads.unit.test.ts
+++ b/tests/remote-transport-path-reads.unit.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, describe, beforeEach, afterEach } from "vitest";
 import { kubectlApply } from "../src/tools/kubectl-apply.js";
 import { kubectlDelete } from "../src/tools/kubectl-delete.js";
+import { kubectlPatch } from "../src/tools/kubectl-patch.js";
 import {
   installHelmChart,
   upgradeHelmChart,
@@ -58,6 +59,18 @@ describe("server-side path params are rejected on remote transports", () => {
           filename: "/etc/passwd",
         })
       ).rejects.toThrow(/'filename'.*disabled on remote/s);
+    });
+
+    test(`kubectl_patch rejects patchFile under ${envVar}`, async () => {
+      process.env[envVar] = "true";
+      await expect(
+        kubectlPatch(manager, {
+          resourceType: "configmaps",
+          name: "leak",
+          patchFile: "/etc/passwd",
+          dryRun: true,
+        })
+      ).rejects.toThrow(/'patchFile'.*disabled on remote/s);
     });
 
     test(`install_helm_chart rejects valuesFile under ${envVar}`, async () => {


### PR DESCRIPTION
PRs #332 and #346 restricted server-side filesystem path params on remote (SSE / Streamable HTTP) transports, where the path resolves on the MCP server host rather than the client's machine:

- `kubectl_create`: `filename`, `fromFile` (#332)
- `kubectl_apply`: `filename` (#346)
- `kubectl_delete`: `filename` (#346)
- `install_helm_chart` / `upgrade_helm_chart`: `valuesFile` (#346)

`kubectl_patch`'s `patchFile` (`--patch-file`) is the same shape of parameter but was missed by that sweep.

## Changes

- `src/tools/kubectl-patch.ts`: apply the identical `isRemoteTransport()` guard — reject `patchFile` on remote transports and point callers at the inline `patchData` parameter, which is safe on every transport. The tool schema now documents the restriction the same way the sibling tools do. Stdio behavior is unchanged.
- `tests/remote-transport-path-reads.unit.test.ts`: cover `kubectl_patch` / `patchFile` under both transport env vars, closing the coverage gap that let this diverge from the sibling tools.

## Testing

- `npx vitest run tests/remote-transport-path-reads.unit.test.ts` — 12 passed
- `npx vitest run tests/kubectl-patch.test.ts` — 4 passed (live cluster)
- `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)