### PR TITLE
fix: reject unknown tool names in ALLOWED_TOOLS instead of ignoring them

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -157,6 +157,11 @@ You can specify a comma-separated list of tool names to enable only those specif
 ALLOWED_TOOLS="kubectl_get,kubectl_describe" npx mcp-server-kubernetes
 ```
 
+Every name in the list must match an existing tool. If any name is unknown, the
+server prints the offending names along with the available tools and exits
+without starting — a typo silently removing a tool you meant to allow would
+leave you with a narrower set of tools than you configured.
+
 In your Claude Desktop configuration:
 
 ```json

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,6 +169,43 @@ const allTools = [
   pingSchema,
 ];
 
+/**
+ * Returns the names in `allowedToolNames` that no tool actually provides.
+ *
+ * Exported for testing.
+ */
+export function findUnknownToolNames(
+  allowedToolNames: Iterable<string>,
+  knownToolNames: Iterable<string>
+): string[] {
+  const known = new Set(knownToolNames);
+  return [...allowedToolNames].filter((name) => !known.has(name)).sort();
+}
+
+// A misspelled name in ALLOWED_TOOLS would otherwise be dropped silently,
+// leaving a narrower tool surface than was configured. Refuse to start instead.
+if (explicitlyAllowedToolNames) {
+  const unknownToolNames = findUnknownToolNames(
+    explicitlyAllowedToolNames,
+    allTools.map((tool) => tool.name)
+  );
+
+  if (unknownToolNames.length > 0) {
+    console.error(
+      `ALLOWED_TOOLS contains unknown tool ${
+        unknownToolNames.length === 1 ? "name" : "names"
+      }: ${unknownToolNames.join(", ")}`
+    );
+    console.error(
+      `Available tools: ${allTools
+        .map((tool) => tool.name)
+        .sort()
+        .join(", ")}`
+    );
+    process.exit(1);
+  }
+}
+
 const k8sManager = new KubernetesManager();
 
 const server = new Server(

--- a/tests/allowed_tools_validation.unit.test.ts
+++ b/tests/allowed_tools_validation.unit.test.ts
@@ -1,0 +1,39 @@
+import { expect, test, describe } from "vitest";
+import { allTools, findUnknownToolNames } from "../src/index";
+
+/**
+ * Verifies that an ALLOWED_TOOLS allowlist is validated against the tools the
+ * server actually provides, so a typo cannot silently narrow the tool surface.
+ */
+describe("ALLOWED_TOOLS name validation", () => {
+  const knownToolNames = allTools.map((tool) => tool.name);
+
+  test("accepts names that match existing tools", () => {
+    expect(
+      findUnknownToolNames(["kubectl_get", "kubectl_describe"], knownToolNames)
+    ).toEqual([]);
+  });
+
+  test("reports a misspelled name", () => {
+    expect(
+      findUnknownToolNames(["kubectl_get", "kubectl_gett"], knownToolNames)
+    ).toEqual(["kubectl_gett"]);
+  });
+
+  test("reports every unknown name, sorted", () => {
+    expect(
+      findUnknownToolNames(
+        ["kubectl_delete", "zzz_unknown", "aaa_unknown"],
+        knownToolNames
+      )
+    ).toEqual(["aaa_unknown", "zzz_unknown"]);
+  });
+
+  test("accepts an allowlist naming every tool", () => {
+    expect(findUnknownToolNames(knownToolNames, knownToolNames)).toEqual([]);
+  });
+
+  test("accepts an empty allowlist", () => {
+    expect(findUnknownToolNames([], knownToolNames)).toEqual([]);
+  });
+});

--- a/tests/tool_restriction_enforcement.test.ts
+++ b/tests/tool_restriction_enforcement.test.ts
@@ -107,4 +107,25 @@ describe("tool restriction enforcement (tools/call layer)", () => {
       )
     ).rejects.toThrow(/not allowed/i);
   }, 30000);
+
+  test("ALLOWED_TOOLS lists exactly the named tools", async () => {
+    const c = await connectWithEnv({ ALLOWED_TOOLS: "kubectl_get,ping" });
+
+    const list = (await c.request(
+      { method: "tools/list", params: {} },
+      // @ts-ignore - minimal schema; we only inspect names
+      z.any()
+    )) as { tools: Array<{ name: string }> };
+
+    expect(list.tools.map((t) => t.name).sort()).toEqual([
+      "kubectl_get",
+      "ping",
+    ]);
+  }, 30000);
+
+  test("ALLOWED_TOOLS with an unknown name stops the server from starting", async () => {
+    await expect(
+      connectWithEnv({ ALLOWED_TOOLS: "kubectl_get,kubectl_gett" })
+    ).rejects.toThrow();
+  }, 30000);
 });


### PR DESCRIPTION
BODY:
## Problem

`ALLOWED_TOOLS` is parsed straight into a `Set` and every lookup is a membership test:

```ts
const explicitlyAllowedToolNames = allowedToolsEnv
  ? new Set(allowedToolsEnv.split(",").map((t) => t.trim()).filter(Boolean))
  : null;
```

A name that doesn't correspond to any tool is therefore accepted and then never matches. The server starts normally and the tool is simply absent from `tools/list`, so `ALLOWED_TOOLS="kubectl_get,kubectl_appply"` silently yields a narrower tool surface than the one that was configured.

This is worth catching because `ALLOWED_TOOLS` is the highest-priority of the three filtering modes and overrides both others, so it is the one people reach for when they want an exact set. The symptom of a typo is also easy to misread: the tool is missing from the model's inventory, which looks like a model problem rather than a config error. In #194 `ALLOWED_TOOLS` is described as being used to restrict a live multi-user deployment — that's the setting where a quietly dropped name is least likely to be noticed.

## Change

Validate the names once at startup against the tools the server actually registers. On an unknown name, print it together with the available tools and exit instead of starting:

```
$ ALLOWED_TOOLS="kubectl_get,kubectl_gett" node dist/index.js
ALLOWED_TOOLS contains unknown tool name: kubectl_gett
Available tools: cleanup, exec_in_pod, explain_resource, install_helm_chart, kubectl_apply, ...
```

All unknown names are reported at once, sorted, so a list with several typos takes one round trip to fix. Valid configurations are unaffected — no change to `isToolAllowed`, to the other two filtering modes, or to startup when `ALLOWED_TOOLS` is unset.

## Tests

- `tests/allowed_tools_validation.unit.test.ts` — new; covers a valid list, a single typo, several typos, an allowlist naming every tool, and an empty list.
- `tests/tool_restriction_enforcement.test.ts` — two added cases: `ALLOWED_TOOLS` lists exactly the named tools, and an unknown name stops the server from starting.

Verified locally: `npm run build` clean, the new unit tests pass, and the fail-closed and normal-startup paths were exercised against the built server. The pre-existing failures in `tests/unit.test.ts` reproduce unchanged on `main` in my environment (they spawn `bun`, which I don't have installed) and are unrelated to this change.

## Note

Same fail-closed rule I contributed to `chigwell/telegram-mcp` in chigwell/telegram-mcp#168, where a named-tool allowlist has the same failure mode. Happy to adjust the message wording or turn the exit into a thrown error if you'd rather keep startup failures uniform.
