### PR TITLE
feat: let ALLOWED_TOOLS extend the read-only set instead of replacing it

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -178,6 +178,32 @@ In your Claude Desktop configuration:
 }
 ```
 
+##### Read-Only Tools Plus a Few Named Ones
+
+A list that starts with `read-only+` is added to the [read-only tools](#read-only-mode) instead of replacing them. This is the common case of "let the agent look at everything, but only write through these specific tools" — without it, exposing one write tool means listing every read-only tool by hand and keeping that list in sync with new releases.
+
+```shell
+ALLOWED_TOOLS="read-only+kubectl_scale,kubectl_rollout" npx mcp-server-kubernetes
+```
+
+That exposes every read-only tool plus `kubectl_scale` and `kubectl_rollout`; every other write tool, `kubectl_delete` and `kubectl_generic` included, stays out of `tools/list` and is refused if called by name. `readonly+` is accepted as well, and the names after the prefix are validated exactly like a plain list, so a typo still stops the server instead of quietly dropping the tool.
+
+In your Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "kubernetes-readonly-plus-scaling": {
+      "command": "npx",
+      "args": ["mcp-server-kubernetes"],
+      "env": {
+        "ALLOWED_TOOLS": "read-only+kubectl_scale,kubectl_rollout"
+      }
+    }
+  }
+}
+```
+
 #### Read-Only Mode
 
 For the strictest level of safety, you can enable read-only mode. This mode only permits tools that cannot alter the cluster state.
@@ -192,6 +218,7 @@ The following tools are available in read-only mode:
 - `kubectl_describe`
 - `kubectl_logs`
 - `kubectl_context`
+- `kubectl_reconnect`
 - `explain_resource`
 - `list_api_resources`
 - `ping`

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,16 +86,64 @@ const allowedToolsEnv = process.env.ALLOWED_TOOLS;
 const nonDestructiveTools =
   process.env.ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS === "true";
 
-const explicitlyAllowedToolNames = allowedToolsEnv
-  ? new Set(allowedToolsEnv.split(",").map((t) => t.trim()).filter(Boolean))
-  : null;
+// Prefixes that start an ALLOWED_TOOLS list from the read-only tool set
+// instead of from nothing. Both spellings of "read-only" are accepted.
+const READONLY_BASELINE_PREFIXES = ["read-only+", "readonly+"];
+
+export interface AllowedTools {
+  /** Tool names listed explicitly. */
+  names: Set<string>;
+  /** Whether every read-only tool is allowed on top of `names`. */
+  withReadonlyBaseline: boolean;
+}
+
+/**
+ * Parses an ALLOWED_TOOLS value.
+ *
+ * `kubectl_get,ping` allows exactly the named tools. `read-only+kubectl_scale`
+ * allows every read-only tool plus the named ones, so exposing one write tool
+ * does not require re-listing the whole read-only set by hand.
+ *
+ * Exported for testing.
+ */
+export function parseAllowedTools(
+  value: string | undefined
+): AllowedTools | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  const matchedPrefix = READONLY_BASELINE_PREFIXES.find((prefix) =>
+    trimmed.toLowerCase().startsWith(prefix)
+  );
+  const listed = matchedPrefix ? trimmed.slice(matchedPrefix.length) : trimmed;
+
+  return {
+    names: new Set(
+      listed
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean)
+    ),
+    withReadonlyBaseline: matchedPrefix !== undefined,
+  };
+}
+
+const allowedTools = parseAllowedTools(allowedToolsEnv);
+
+const isReadonlyTool = (name: string): boolean =>
+  readonlyTools.some((t) => t.name === name);
 
 const isToolAllowed = (name: string): boolean => {
-  if (explicitlyAllowedToolNames) {
-    return explicitlyAllowedToolNames.has(name);
+  if (allowedTools) {
+    if (allowedTools.names.has(name)) {
+      return true;
+    }
+    return allowedTools.withReadonlyBaseline && isReadonlyTool(name);
   }
   if (allowOnlyReadonlyTools) {
-    return readonlyTools.some((t) => t.name === name);
+    return isReadonlyTool(name);
   }
   if (nonDestructiveTools) {
     return !destructiveTools.some((dt) => dt.name === name);
@@ -184,9 +232,9 @@ export function findUnknownToolNames(
 
 // A misspelled name in ALLOWED_TOOLS would otherwise be dropped silently,
 // leaving a narrower tool surface than was configured. Refuse to start instead.
-if (explicitlyAllowedToolNames) {
+if (allowedTools) {
   const unknownToolNames = findUnknownToolNames(
-    explicitlyAllowedToolNames,
+    allowedTools.names,
     allTools.map((tool) => tool.name)
   );
 
@@ -238,8 +286,9 @@ registerPromptHandlers(server, k8sManager);
 
 // Tools handlers
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  const baseTools = allowOnlyReadonlyTools ? readonlyTools : allTools;
-  const tools = baseTools.filter((tool) => isToolAllowed(tool.name));
+  // isToolAllowed is the single source of truth, so tools/list and tools/call
+  // cannot disagree about which tools the current configuration exposes.
+  const tools = allTools.filter((tool) => isToolAllowed(tool.name));
   return { tools };
 });
 

--- a/tests/allowed_tools_parsing.unit.test.ts
+++ b/tests/allowed_tools_parsing.unit.test.ts
@@ -1,0 +1,66 @@
+import { expect, test, describe } from "vitest";
+import { parseAllowedTools } from "../src/index";
+
+/**
+ * Verifies how an ALLOWED_TOOLS value is parsed, in particular the
+ * "read-only+<tools>" form that adds named tools on top of the read-only set
+ * instead of replacing it.
+ */
+describe("ALLOWED_TOOLS parsing", () => {
+  test("returns null when unset or empty", () => {
+    expect(parseAllowedTools(undefined)).toBeNull();
+    expect(parseAllowedTools("")).toBeNull();
+  });
+
+  test("a plain list names the tools exhaustively", () => {
+    const parsed = parseAllowedTools("kubectl_get,ping");
+
+    expect(parsed?.withReadonlyBaseline).toBe(false);
+    expect([...(parsed?.names ?? [])].sort()).toEqual(["kubectl_get", "ping"]);
+  });
+
+  test("the read-only+ prefix keeps the read-only baseline", () => {
+    const parsed = parseAllowedTools("read-only+kubectl_scale,kubectl_apply");
+
+    expect(parsed?.withReadonlyBaseline).toBe(true);
+    expect([...(parsed?.names ?? [])].sort()).toEqual([
+      "kubectl_apply",
+      "kubectl_scale",
+    ]);
+  });
+
+  test("the prefix is accepted as readonly+ and case-insensitively", () => {
+    expect(parseAllowedTools("readonly+kubectl_scale")).toEqual({
+      names: new Set(["kubectl_scale"]),
+      withReadonlyBaseline: true,
+    });
+    expect(parseAllowedTools("Read-Only+kubectl_scale")).toEqual({
+      names: new Set(["kubectl_scale"]),
+      withReadonlyBaseline: true,
+    });
+  });
+
+  test("surrounding whitespace is ignored", () => {
+    const parsed = parseAllowedTools("  read-only+ kubectl_scale , ping  ");
+
+    expect(parsed?.withReadonlyBaseline).toBe(true);
+    expect([...(parsed?.names ?? [])].sort()).toEqual(["kubectl_scale", "ping"]);
+  });
+
+  test("the prefix alone is the read-only set with nothing added", () => {
+    const parsed = parseAllowedTools("read-only+");
+
+    expect(parsed?.withReadonlyBaseline).toBe(true);
+    expect([...(parsed?.names ?? [])]).toEqual([]);
+  });
+
+  test("the prefix counts only at the start of the value", () => {
+    const parsed = parseAllowedTools("kubectl_get,read-only+ping");
+
+    expect(parsed?.withReadonlyBaseline).toBe(false);
+    expect([...(parsed?.names ?? [])].sort()).toEqual([
+      "kubectl_get",
+      "read-only+ping",
+    ]);
+  });
+});

--- a/tests/tool_restriction_enforcement.test.ts
+++ b/tests/tool_restriction_enforcement.test.ts
@@ -128,4 +128,51 @@ describe("tool restriction enforcement (tools/call layer)", () => {
       connectWithEnv({ ALLOWED_TOOLS: "kubectl_get,kubectl_gett" })
     ).rejects.toThrow();
   }, 30000);
+
+  test("ALLOWED_TOOLS read-only+ adds named tools to the read-only set", async () => {
+    const c = await connectWithEnv({
+      ALLOWED_TOOLS: "read-only+kubectl_scale",
+    });
+
+    const list = (await c.request(
+      { method: "tools/list", params: {} },
+      // @ts-ignore - minimal schema; we only inspect names
+      z.any()
+    )) as { tools: Array<{ name: string }> };
+    const names = list.tools.map((t) => t.name);
+
+    // The named write tool plus the read-only baseline.
+    expect(names).toContain("kubectl_scale");
+    expect(names).toContain("kubectl_get");
+    expect(names).toContain("ping");
+    // Write tools that were not named stay out.
+    expect(names).not.toContain("kubectl_delete");
+    expect(names).not.toContain("kubectl_apply");
+  }, 30000);
+
+  test("ALLOWED_TOOLS read-only+ rejects an unnamed write tool at call-time", async () => {
+    const c = await connectWithEnv({
+      ALLOWED_TOOLS: "read-only+kubectl_scale",
+    });
+
+    await expect(
+      c.request(
+        {
+          method: "tools/call",
+          params: {
+            name: "kubectl_delete",
+            arguments: { resourceType: "pod", name: "anything" },
+          },
+        },
+        // @ts-ignore - minimal schema
+        z.any()
+      )
+    ).rejects.toThrow(/not allowed/i);
+  }, 30000);
+
+  test("ALLOWED_TOOLS read-only+ with an unknown name stops the server from starting", async () => {
+    await expect(
+      connectWithEnv({ ALLOWED_TOOLS: "read-only+kubectl_scalee" })
+    ).rejects.toThrow();
+  }, 30000);
 });


### PR DESCRIPTION
## Problem

`ALLOWED_TOOLS` replaces the tool surface outright. That makes the most common restricted setup — *let the agent read anything, but write only through these specific tools* — awkward:

```shell
# expose one write tool, hand-copy the read-only set to keep reads working
ALLOWED_TOOLS="kubectl_get,kubectl_describe,kubectl_logs,kubectl_context,kubectl_reconnect,explain_resource,list_api_resources,ping,kubectl_scale"
```

Eight names of boilerplate for one write tool, and the copy drifts: a read-only tool added in a later release does not reach anyone who wrote the list out by hand. `ALLOW_ONLY_READONLY_TOOLS` cannot help either, since it is strictly narrower and lower priority.

## Change

`ALLOWED_TOOLS` now accepts a `read-only+` prefix that starts the allowlist from the read-only tools instead of from nothing:

```shell
ALLOWED_TOOLS="read-only+kubectl_scale,kubectl_rollout" npx mcp-server-kubernetes
```

That exposes every read-only tool plus `kubectl_scale` and `kubectl_rollout`. Every other write tool — `kubectl_delete`, `kubectl_generic`, the Helm mutations — stays out of `tools/list` and is refused at call-time. `readonly+` is accepted as an alternate spelling, and the names after the prefix are validated exactly like a plain list, so a typo still stops the server (#356) rather than quietly narrowing the surface.

Parsing moved into an exported `parseAllowedTools`, so the prefix is handled in one place and is unit-testable without spawning a server.

### One behaviour fix that came with it

`tools/list` now filters `allTools` through `isToolAllowed` instead of choosing its own base set. Previously, with `ALLOW_ONLY_READONLY_TOOLS=true` **and** `ALLOWED_TOOLS` naming a write tool, `tools/list` hid that tool while `tools/call` allowed it — the two layers disagreed, even though `ALLOWED_TOOLS` is documented as the higher-priority mode. `isToolAllowed` is now the single source of truth for both.

Behaviour with no `ALLOWED_TOOLS` set is unchanged, as is a plain comma-separated list.

## Tests

- `tests/allowed_tools_parsing.unit.test.ts` (new, 7 cases): prefix detection, `readonly+` and case variants, whitespace, `read-only+` with nothing after it, and the prefix being ignored anywhere but the start.
- `tests/tool_restriction_enforcement.test.ts` (+3 cases): `read-only+kubectl_scale` lists the read-only set plus `kubectl_scale` and omits `kubectl_delete`/`kubectl_apply`; an unnamed write tool is refused at call-time; an unknown name after the prefix stops startup.

All 22 tests in the four tool-filtering test files pass, and `tsc --noEmit` is clean. The `unit.test.ts` cases that create cluster resources fail in my environment for lack of a cluster (`Executable not found in $PATH: "kubectl"`), unrelated to this change; `list available tools` in that file passes.

## Docs

`ADVANCED_README.md` gains a subsection under *Allowed Tools List* with the shell and Claude Desktop forms. Also adds `kubectl_reconnect` to the documented read-only tool list — it is in `readonlyTools` in `src/index.ts` but was missing from the docs, and that list now defines what `read-only+` grants.

Follow-up to #356. The mechanism mirrors the `read-only+<tools>` syntax I contributed to [chigwell/telegram-mcp#168](https://github.com/chigwell/telegram-mcp/pull/168), where the same baseline-plus-named-tools problem came up.
