### PR TITLE
security: restrict fromFile paths to MCP_SERVER_ALLOWED_FILE_ROOT

### DIFF
--- a/src/tools/kubectl-create.ts
+++ b/src/tools/kubectl-create.ts
@@ -178,6 +178,28 @@ export const kubectlCreateSchema = {
   },
 } as const;
 
+function resolveAllowedFromFile(file: string): string {
+  const allowedRoot = process.env.MCP_SERVER_ALLOWED_FILE_ROOT;
+  if (!allowedRoot) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      "fromFile is disabled unless MCP_SERVER_ALLOWED_FILE_ROOT is configured"
+    );
+  }
+  const eq = file.indexOf("=");
+  const prefix = eq === -1 ? "" : file.slice(0, eq + 1);
+  const rawPath = eq === -1 ? file : file.slice(eq + 1);
+  const root = path.resolve(allowedRoot);
+  const resolved = path.resolve(rawPath);
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      "fromFile path is outside the allowed root"
+    );
+  }
+  return `${prefix}${resolved}`;
+}
+
 export async function kubectlCreate(
   k8sManager: KubernetesManager,
   input: {
@@ -338,10 +360,10 @@ export async function kubectlCreate(
           }
 
           // Add --from-file arguments (server-side paths; blocked on remote
-          // transports by the guard above)
+          // transports by the guard above, and path-validated here)
           if (input.fromFile && input.fromFile.length > 0) {
             input.fromFile.forEach((file) => {
-              args.push(`--from-file=${file}`);
+              args.push(`--from-file=${resolveAllowedFromFile(file)}`);
             });
           }
 
@@ -369,10 +391,10 @@ export async function kubectlCreate(
           }
 
           // Add --from-file arguments (server-side paths; blocked on remote
-          // transports by the guard above)
+          // transports by the guard above, and path-validated here)
           if (input.fromFile && input.fromFile.length > 0) {
             input.fromFile.forEach((file) => {
-              args.push(`--from-file=${file}`);
+              args.push(`--from-file=${resolveAllowedFromFile(file)}`);
             });
           }
 


### PR DESCRIPTION
## Summary

Fixes GHSA-x4x5-wv5h-jjf8 / CVE-2026-77441 — arbitrary local file read via `kubectl_create --from-file`.

The `fromFile` parameter accepted caller-controlled paths and passed them verbatim as `--from-file=<path>` to kubectl. Combined with `dryRun=true` and `output=yaml`, kubectl reads the file and returns its contents base64-encoded in the Secret/ConfigMap YAML response — with no cluster connection required.

## Changes

**`src/tools/kubectl-create.ts`**

Adds `resolveAllowedFromFile(file)` and applies it in both the `configmap` and `secret` branches before appending `--from-file` args:

- Requires `MCP_SERVER_ALLOWED_FILE_ROOT` to be set; throws `InvalidParams` if not configured
- Resolves the caller-supplied path and rejects anything that falls outside the configured root
- Correctly handles both bare paths (`/path/to/file`) and the `key=/path/to/file` syntax kubectl accepts

## Migration

`fromFile` is now **disabled by default**. To re-enable it, set the env var to an explicit allowed directory:

```sh
MCP_SERVER_ALLOWED_FILE_ROOT=/safe/project/directory
```

Any path outside that root is rejected with an error. Callers on all transports can always use `fromFileContent` (inline content) as a safe alternative with no configuration required.

## References

- GHSA-x4x5-wv5h-jjf8
- CVE-2026-77441