### PR TITLE
chore: upgrade actions/checkout to v5 and dorny/test-reporter to v3 (Node.js 24)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -53,7 +53,7 @@ jobs:
           bun run test --reporter default --reporter junit --outputFile junit-results.xml
 
       - name: Test Report
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         if: always()
         with:
           name: Bun Tests # Name of the check run which will be created


### PR DESCRIPTION
## Summary

Resolves deprecation warnings introduced by the [Node.js 20 deprecation on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (effective 2025-09-19).

CI was emitting:
```
Warning: Node.js 20 is deprecated. The following actions target Node.js 20
but are being forced to run on Node.js 24: actions/checkout@v4, dorny/test-reporter@v2.
```

## Changes

| File | Before | After |
|------|--------|-------|
| `.github/workflows/ci.yml` | `actions/checkout@v4` | `actions/checkout@v5` |
| `.github/workflows/ci.yml` | `dorny/test-reporter@v2` | `dorny/test-reporter@v3` |
| `.github/workflows/cd.yml` | `actions/checkout@v4` | `actions/checkout@v5` |

Both `actions/checkout@v5` and `dorny/test-reporter@v3` declare `using: node24` natively, eliminating the forced-upgrade warnings. No functional changes to workflow logic.

## References

- [GitHub Changelog: Deprecation of Node.js 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- [actions/checkout v5 release](https://github.com/actions/checkout/releases/tag/v5.0.0)
- [dorny/test-reporter v3 release](https://github.com/dorny/test-reporter/releases/tag/v3.0.0)