### PR TITLE
chore: update server.json for MCP OSS registry publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -92,7 +92,7 @@ jobs:
           # Update the version in all files using the npm script
           npm run version:update ${{ steps.version.outputs.current-version }}
 
-          git add package.json src/config/server-config.ts manifest.json CITATION.cff README.md gemini-extension.json
+          git add package.json src/config/server-config.ts manifest.json CITATION.cff README.md gemini-extension.json server.json
           git commit -m "Bump version to ${{ steps.version.outputs.current-version }}"
 
           # Create and push the tag

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -53,6 +53,15 @@ const files = [
       ext.version = version;
       return JSON.stringify(ext, null, 2) + '\n';
     }
+  },
+  {
+    path: 'server.json',
+    update: (content) => {
+      const server = JSON.parse(content);
+      server.version = version;
+      server.packages[0].version = version;
+      return JSON.stringify(server, null, 2) + '\n';
+    }
   }
 ];
 

--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.Flux159/mcp-server-kubernetes",
   "description": "MCP server for interacting with Kubernetes clusters via kubectl",
   "status": "active",
@@ -7,70 +7,160 @@
     "url": "https://github.com/Flux159/mcp-server-kubernetes",
     "source": "github"
   },
-  "version": "2.9.4",
+  "version": "4.1.4",
   "packages": [
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "mcp-server-kubernetes",
-      "version": "2.9.4",
+      "version": "4.1.4",
       "transport": {
         "type": "stdio"
       },
       "environment_variables": [
         {
-          "description": "Non destructive mode.",
+          "name": "KUBECONFIG_YAML",
+          "description": "Kubeconfig supplied as a YAML string. Takes priority over KUBECONFIG_PATH.",
           "is_required": false,
-          "format": "string",
-          "name": "ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS"
+          "format": "string"
         },
         {
-          "description": "Read only mode.",
+          "name": "KUBECONFIG_JSON",
+          "description": "Kubeconfig supplied as a JSON string. Takes priority over KUBECONFIG_PATH.",
           "is_required": false,
-          "format": "string",
-          "name": "ALLOW_ONLY_READONLY_TOOLS"
+          "format": "string"
         },
         {
-          "description": "Comma delimited list of allowed tools.",
+          "name": "KUBECONFIG_PATH",
+          "description": "Path to the kubeconfig file. Defaults to ~/.kube/config.",
           "is_required": false,
-          "format": "string",
-          "name": "ALLOWED_TOOLS"
+          "format": "string"
         },
         {
-          "description": "Set to false to disable automatic secrets masking in responses.",
+          "name": "ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS",
+          "description": "Set to 'true' to expose only non-destructive tools (excludes kubectl_delete, exec_in_pod, node_management, and Helm uninstall).",
           "is_required": false,
-          "format": "string",
-          "name": "MASK_SECRETS"
+          "format": "string"
         },
         {
-          "description": "Enable Streamable HTTP Transport.",
+          "name": "ALLOW_ONLY_READONLY_TOOLS",
+          "description": "Set to 'true' to expose only read-only tools (get, describe, logs, explain, context listing).",
           "is_required": false,
-          "format": "string",
-          "name": "ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT"
+          "format": "string"
         },
         {
-          "description": "Enable SSE Transport.",
+          "name": "ALLOWED_TOOLS",
+          "description": "Comma-delimited allowlist of specific tool names to expose. All other tools are hidden.",
           "is_required": false,
-          "format": "string",
-          "name": "ENABLE_UNSAFE_SSE_TRANSPORT"
+          "format": "string"
         },
         {
-          "description": "Specify kubeconfig as a yaml string.",
+          "name": "MASK_SECRETS",
+          "description": "Set to 'false' to disable automatic masking of Kubernetes Secret values in responses. Masking is enabled by default.",
           "is_required": false,
-          "format": "string",
-          "name": "KUBECONFIG_YAML"
+          "format": "string"
         },
         {
-          "description": "Specify kubeconfig as a json string.",
+          "name": "ALLOW_KUBECTL_UNSAFE_FLAGS",
+          "description": "Set to 'true' to allow kubectl flags that redirect API connections (e.g. --server, --token, --kubeconfig). Disabled by default as a defence against prompt-injection attacks.",
           "is_required": false,
-          "format": "string",
-          "name": "KUBECONFIG_JSON"
+          "format": "string"
         },
         {
-          "description": "Specify kubeconfig file path. Defaults to ~/.kube/config",
+          "name": "ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT",
+          "description": "Set to '1' to enable the Streamable HTTP transport. Requires HOST and PORT. Pair with MCP_AUTH_TOKEN in production.",
           "is_required": false,
-          "format": "string",
-          "name": "KUBECONFIG_PATH"
+          "format": "string"
+        },
+        {
+          "name": "ENABLE_UNSAFE_SSE_TRANSPORT",
+          "description": "Set to '1' to enable the legacy SSE transport. Pair with MCP_AUTH_TOKEN in production.",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "HOST",
+          "description": "Bind address for the HTTP transport. Defaults to 'localhost'. Set to '0.0.0.0' only in isolated/containerised environments.",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "PORT",
+          "description": "Port for the HTTP transport. Defaults to 3000.",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "MCP_AUTH_TOKEN",
+          "description": "Shared-secret token for the HTTP transport. When set, every request must include the header 'X-MCP-AUTH: <token>'. Strongly recommended when HOST is not localhost.",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "DNS_REBINDING_PROTECTION",
+          "description": "Set to 'false' to disable DNS rebinding protection on the HTTP transport. Protection is enabled by default.",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "DNS_REBINDING_ALLOWED_HOST",
+          "description": "Override the allowed Host header value checked by DNS rebinding protection. Useful when the server is accessed through a reverse proxy.",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "SPAWN_MAX_BUFFER",
+          "description": "Maximum output buffer size in bytes for kubectl command execution. Defaults to 1048577 (1 MB + 1 byte).",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "ENABLE_TELEMETRY",
+          "description": "Set to 'true' or '1' to enable OpenTelemetry tracing. Also requires OTEL_EXPORTER_OTLP_ENDPOINT to be set.",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
+          "description": "OTLP endpoint URL for exporting traces (e.g. http://localhost:4318). Required when ENABLE_TELEMETRY is set.",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "OTEL_SERVICE_NAME",
+          "description": "Service name reported in OpenTelemetry traces.",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "OTEL_SERVICE_VERSION",
+          "description": "Service version reported in OpenTelemetry traces.",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "OTEL_RESOURCE_ATTRIBUTES",
+          "description": "Additional key=value resource attributes attached to every OpenTelemetry span.",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "OTEL_TRACES_SAMPLER",
+          "description": "OpenTelemetry trace sampler name (e.g. 'always_on', 'always_off', 'traceidratio').",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "OTEL_TRACES_SAMPLER_ARG",
+          "description": "Argument passed to the configured OTEL_TRACES_SAMPLER (e.g. a sampling ratio like '0.1').",
+          "is_required": false,
+          "format": "string"
+        },
+        {
+          "name": "OTEL_CAPTURE_RESPONSE_METADATA",
+          "description": "Set to 'false' or '0' to exclude tool response metadata from OpenTelemetry spans. Captured by default.",
+          "is_required": false,
+          "format": "string"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Brings `server.json` up to date in preparation for publishing to the [MCP OSS registry](https://github.com/modelcontextprotocol/registry).

## Changes

### `server.json`
- **Version**: `2.9.4` → `4.1.4`
- **Schema**: `2025-07-09` → `2025-10-17` (latest)
- **Environment variables**: 9 → 24 — adds all variables introduced since 2.9.4:

| New variable | Purpose |
|---|---|
| `MCP_AUTH_TOKEN` | Shared-secret auth for HTTP transport (`X-MCP-AUTH` header) |
| `HOST` | Bind address for HTTP transport (default: `localhost`) |
| `PORT` | Port for HTTP transport (default: `3000`) |
| `DNS_REBINDING_PROTECTION` | Disable DNS rebinding protection (default: enabled) |
| `DNS_REBINDING_ALLOWED_HOST` | Custom allowed Host for reverse-proxy deployments |
| `ALLOW_KUBECTL_UNSAFE_FLAGS` | Allow connection-redirecting kubectl flags (disabled by default) |
| `SPAWN_MAX_BUFFER` | Max kubectl output buffer in bytes (default: 1 MB) |
| `ENABLE_TELEMETRY` | Enable OpenTelemetry tracing |
| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint for trace export |
| `OTEL_SERVICE_NAME` | Service name in traces |
| `OTEL_SERVICE_VERSION` | Service version in traces |
| `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes on spans |
| `OTEL_TRACES_SAMPLER` | Trace sampler name |
| `OTEL_TRACES_SAMPLER_ARG` | Trace sampler argument |
| `OTEL_CAPTURE_RESPONSE_METADATA` | Include response metadata in spans (default: enabled) |

### `scripts/update-version.js`
Adds `server.json` to the version-bump script so both `version` and `packages[0].version` stay in sync on every release.

### `.github/workflows/cd.yml`
Adds `server.json` to the `git add` step in the CD workflow so the version commit includes it automatically.

## Next step

Once this merges, the next step is opening a PR to [modelcontextprotocol/registry](https://github.com/modelcontextprotocol/registry) to publish to the OSS MCP registry.