### PR TITLE
Reject flag-shaped operands in helm tool arguments

### DIFF
--- a/src/security/kubectl-flags.ts
+++ b/src/security/kubectl-flags.ts
@@ -80,7 +80,8 @@ const SHORT_VALUE_FLAGS = new Set<string>([
 ]);
 
 // helm exposes the same exfiltration surface as kubectl, but under "kube-"
-// prefixed flag names (e.g. --kube-apiserver instead of --server). We add
+// prefixed flag names (e.g. --kube-apiserver instead of --server), plus a few
+// helm-only flags that run or overwrite things on the MCP server host. We add
 // those here so the argv-level guard covers helm invocations too. Context
 // selection flags (--context / --kube-context) are intentionally omitted:
 // they can only select a cluster already present in the loaded kubeconfig,
@@ -94,6 +95,18 @@ const HELM_DANGEROUS_FLAGS = new Set<string>([
   "kube-as-group",
   "kube-tls-server-name",
   "kube-insecure-skip-tls-verify",
+
+  // Runs a binary on the MCP server host: helm 3.x resolves --post-renderer to
+  // an executable path (or a $PATH name) and runs it over the rendered
+  // manifests. Nothing about installing a chart otherwise gives host-side
+  // execution, so this is never a flag a tool should emit.
+  "post-renderer",
+  "post-renderer-args",
+
+  // Writes to attacker-chosen filesystem paths: helm rewrites these files as
+  // part of "repo add" / registry login.
+  "repository-config",
+  "registry-config",
 ]);
 
 // Flag names that are dangerous when they appear anywhere in a fully
@@ -175,10 +188,10 @@ function reject(flag: string): never {
   throw new McpError(
     ErrorCode.InvalidParams,
     `Refusing to run kubectl with flag "${flag}": this flag can redirect ` +
-      `kubectl to a different API server or substitute credentials, which ` +
-      `would allow exfiltration of the operator's bearer token. If you ` +
-      `genuinely need this flag, set ALLOW_KUBECTL_UNSAFE_FLAGS=true in the ` +
-      `server environment.`
+      `kubectl/helm to a different API server, substitute credentials, or ` +
+      `act on the MCP server's own host, which would allow exfiltration of ` +
+      `the operator's bearer token. If you genuinely need this flag, set ` +
+      `ALLOW_KUBECTL_UNSAFE_FLAGS=true in the server environment.`
   );
 }
 
@@ -236,6 +249,38 @@ export function assertSafeArgv(args: readonly string[]): void {
     // first one.
     if (hasDangerousShortFlag(tok)) reject(tok);
   }
+}
+
+/**
+ * Reject a caller-supplied value that a tool is about to place in a *positional*
+ * argv slot (a release name, a chart reference, a namespace) when it is shaped
+ * like a command-line flag.
+ *
+ * assertSafeArgv is a deny-list: it can only refuse the flags it knows about,
+ * so every dangerous flag added upstream is exploitable through any positional
+ * slot until the list is extended. This guard closes the injection point
+ * instead of chasing the flags: pflag treats any token starting with "-" as a
+ * flag no matter where it sits, and none of these operands is ever legitimately
+ * flag-shaped (helm release names and namespaces are RFC 1123 names; chart
+ * references are repo/name pairs, paths or URLs). Refusing a leading "-" here
+ * means caller data can never occupy a slot where it would be parsed as a flag.
+ *
+ * Honours the same ALLOW_KUBECTL_UNSAFE_FLAGS escape hatch as the flag guard.
+ */
+export function assertNotFlagLike(
+  value: string | undefined,
+  field: string
+): void {
+  if (isUnsafeFlagsAllowed()) return;
+  if (typeof value !== "string" || !value.startsWith("-")) return;
+
+  throw new McpError(
+    ErrorCode.InvalidParams,
+    `Refusing to run helm with ${field}="${value}": a value starting with ` +
+      `"-" is parsed as a command-line flag rather than as the ${field}, ` +
+      `which would let the caller inject arbitrary helm flags. Provide a ` +
+      `${field} that does not begin with "-".`
+  );
 }
 
 /**

--- a/src/tools/helm-operations.ts
+++ b/src/tools/helm-operations.ts
@@ -6,7 +6,10 @@
  */
 
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
-import { execFileSyncSafe } from "../security/kubectl-flags.js";
+import {
+  assertNotFlagLike,
+  execFileSyncSafe,
+} from "../security/kubectl-flags.js";
 import { writeFileSync, unlinkSync } from "fs";
 import { dump } from "js-yaml";
 import { isRemoteTransport } from "../security/transport.js";
@@ -187,6 +190,25 @@ const rejectValuesFileOnRemoteTransport = (valuesFile?: string): void => {
   }
 };
 
+// The release name, chart reference, namespace and repo URL are all placed in
+// positional argv slots ("helm install <name> <chart>", "helm repo add
+// <name> <url>", "kubectl create namespace <ns>"). pflag parses any token
+// beginning with "-" as a flag regardless of position, so a caller-supplied
+// value such as "--post-renderer=/tmp/x.sh" would become a helm flag instead
+// of an operand. Reject flag-shaped operands up front rather than relying on
+// the argv deny-list to know every dangerous helm flag.
+const assertOperandsNotFlagLike = (params: {
+  name: string;
+  chart?: string;
+  namespace: string;
+  repo?: string;
+}): void => {
+  assertNotFlagLike(params.name, "release name");
+  assertNotFlagLike(params.chart, "chart");
+  assertNotFlagLike(params.namespace, "namespace");
+  assertNotFlagLike(params.repo, "repo");
+};
+
 /**
  * Install a Helm chart using template mode (helm template + kubectl apply).
  * This mode bypasses authentication issues and kubeconfig API version mismatches.
@@ -309,6 +331,7 @@ export async function installHelmChart(
   params: HelmInstallOperation
 ): Promise<{ content: { type: string; text: string }[] }> {
   rejectValuesFileOnRemoteTransport(params.valuesFile);
+  assertOperandsNotFlagLike(params);
 
   // Use template mode if requested
   if (params.useTemplate) {
@@ -392,6 +415,7 @@ export async function upgradeHelmChart(
   params: HelmUpgradeOperation
 ): Promise<{ content: { type: string; text: string }[] }> {
   rejectValuesFileOnRemoteTransport(params.valuesFile);
+  assertOperandsNotFlagLike(params);
 
   try {
     // Add repository if provided
@@ -464,6 +488,8 @@ export async function upgradeHelmChart(
 export async function uninstallHelmChart(
   params: HelmUninstallOperation
 ): Promise<{ content: { type: string; text: string }[] }> {
+  assertOperandsNotFlagLike(params);
+
   try {
     executeCommand("helm", [
       "uninstall",

--- a/tests/helm-argument-injection.unit.test.ts
+++ b/tests/helm-argument-injection.unit.test.ts
@@ -1,0 +1,113 @@
+import { expect, test, describe, beforeEach, afterEach } from "vitest";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import {
+  installHelmChart,
+  upgradeHelmChart,
+  uninstallHelmChart,
+} from "../src/tools/helm-operations.js";
+
+// The helm tools put caller-supplied values into positional argv slots
+// ("helm install <name> <chart>"). pflag parses any token starting with "-"
+// as a flag wherever it appears, so those operands must be refused before
+// helm is spawned — otherwise a tool argument becomes a helm flag.
+describe("helm tools reject flag-shaped operands", () => {
+  const originalEnv = process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+
+  beforeEach(() => {
+    delete process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+    } else {
+      process.env.ALLOW_KUBECTL_UNSAFE_FLAGS = originalEnv;
+    }
+  });
+
+  const flagShaped = "--post-renderer=/tmp/payload.sh";
+
+  test("install rejects a flag-shaped release name (template mode)", async () => {
+    await expect(
+      installHelmChart({
+        name: flagShaped,
+        chart: "./charts/mychart",
+        namespace: "default",
+        useTemplate: true,
+        createNamespace: true,
+      })
+    ).rejects.toThrow(McpError);
+  });
+
+  test("install rejects a flag-shaped release name (helm install mode)", async () => {
+    await expect(
+      installHelmChart({
+        name: flagShaped,
+        chart: "./charts/mychart",
+        namespace: "default",
+      })
+    ).rejects.toThrow(/release name/);
+  });
+
+  test("install rejects flag-shaped chart, namespace and repo", async () => {
+    await expect(
+      installHelmChart({
+        name: "my-release",
+        chart: flagShaped,
+        namespace: "default",
+      })
+    ).rejects.toThrow(/chart/);
+
+    await expect(
+      installHelmChart({
+        name: "my-release",
+        chart: "./charts/mychart",
+        namespace: flagShaped,
+      })
+    ).rejects.toThrow(/namespace/);
+
+    await expect(
+      installHelmChart({
+        name: "my-release",
+        chart: "bitnami/nginx",
+        namespace: "default",
+        repo: flagShaped,
+      })
+    ).rejects.toThrow(/repo/);
+  });
+
+  test("upgrade rejects a flag-shaped release name", async () => {
+    await expect(
+      upgradeHelmChart({
+        name: flagShaped,
+        chart: "./charts/mychart",
+        namespace: "default",
+      })
+    ).rejects.toThrow(McpError);
+  });
+
+  test("uninstall rejects a flag-shaped release name", async () => {
+    await expect(
+      uninstallHelmChart({
+        name: flagShaped,
+        namespace: "default",
+      })
+    ).rejects.toThrow(McpError);
+  });
+
+  test("rejection is an InvalidParams McpError, not a 'failed' tool result", async () => {
+    // The tools catch helm failures and return { status: "failed" }; the guard
+    // has to fire before that so the caller sees a hard protocol error.
+    try {
+      await installHelmChart({
+        name: flagShaped,
+        chart: "./charts/mychart",
+        namespace: "default",
+      });
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(McpError);
+      expect((e as McpError).code).toBe(ErrorCode.InvalidParams);
+    }
+  });
+});

--- a/tests/kubectl-flags-security.unit.test.ts
+++ b/tests/kubectl-flags-security.unit.test.ts
@@ -2,6 +2,7 @@ import { expect, test, describe, beforeEach, afterEach } from "vitest";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import {
   assertNoDangerousFlags,
+  assertNotFlagLike,
   assertSafeArgv,
   execFileSyncSafe,
 } from "../src/security/kubectl-flags.js";
@@ -410,6 +411,29 @@ describe("assertSafeArgv (full-argv guard for positional slots)", () => {
     ).toThrow(/kube-token/);
   });
 
+  test("rejects helm flags that run or overwrite things on the host", () => {
+    expect(() =>
+      assertSafeArgv([
+        "template",
+        "rel",
+        "chart",
+        "--post-renderer=/tmp/payload.sh",
+      ])
+    ).toThrow(/post-renderer/);
+    expect(() =>
+      assertSafeArgv(["install", "rel", "chart", "--post_renderer=/tmp/x.sh"])
+    ).toThrow(McpError);
+    expect(() =>
+      assertSafeArgv(["install", "rel", "chart", "--post-renderer-args=x"])
+    ).toThrow(/post-renderer-args/);
+    expect(() =>
+      assertSafeArgv(["repo", "add", "r", "--repository-config=/tmp/x.yaml"])
+    ).toThrow(/repository-config/);
+    expect(() =>
+      assertSafeArgv(["install", "rel", "chart", "--registry-config=/tmp/x"])
+    ).toThrow(/registry-config/);
+  });
+
   test("allows --context (every tool emits it; cannot redirect on its own)", () => {
     expect(() =>
       assertSafeArgv(["get", "pods", "--context", "prod", "-o", "json"])
@@ -437,6 +461,68 @@ describe("assertSafeArgv (full-argv guard for positional slots)", () => {
     process.env.ALLOW_KUBECTL_UNSAFE_FLAGS = "true";
     expect(() =>
       assertSafeArgv(["get", "pods", "--server=https://attacker"])
+    ).not.toThrow();
+  });
+});
+
+describe("assertNotFlagLike", () => {
+  const originalEnv = process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+
+  beforeEach(() => {
+    delete process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.ALLOW_KUBECTL_UNSAFE_FLAGS;
+    } else {
+      process.env.ALLOW_KUBECTL_UNSAFE_FLAGS = originalEnv;
+    }
+  });
+
+  test("rejects long-flag-shaped operands", () => {
+    expect(() =>
+      assertNotFlagLike("--post-renderer=/tmp/payload.sh", "release name")
+    ).toThrow(McpError);
+    // Unknown-to-the-deny-list flags are refused too: the guard keys off the
+    // shape of the value, not off a list of flag names.
+    expect(() => assertNotFlagLike("--some-future-flag=x", "chart")).toThrow(
+      /chart/
+    );
+  });
+
+  test("rejects short-flag-shaped operands and a bare dash", () => {
+    expect(() => assertNotFlagLike("-f/tmp/values.yaml", "chart")).toThrow(
+      McpError
+    );
+    expect(() => assertNotFlagLike("-", "release name")).toThrow(McpError);
+  });
+
+  test("error uses InvalidParams code", () => {
+    try {
+      assertNotFlagLike("--post-renderer=/tmp/x.sh", "release name");
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(McpError);
+      expect((e as McpError).code).toBe(ErrorCode.InvalidParams);
+    }
+  });
+
+  test("allows ordinary release names, charts, namespaces and repo URLs", () => {
+    expect(() => assertNotFlagLike("my-release", "release name")).not.toThrow();
+    expect(() => assertNotFlagLike("bitnami/nginx", "chart")).not.toThrow();
+    expect(() => assertNotFlagLike("./charts/mychart", "chart")).not.toThrow();
+    expect(() => assertNotFlagLike("default", "namespace")).not.toThrow();
+    expect(() =>
+      assertNotFlagLike("https://charts.bitnami.com/bitnami", "repo")
+    ).not.toThrow();
+    expect(() => assertNotFlagLike(undefined, "repo")).not.toThrow();
+  });
+
+  test("ALLOW_KUBECTL_UNSAFE_FLAGS=true bypasses the operand guard", () => {
+    process.env.ALLOW_KUBECTL_UNSAFE_FLAGS = "true";
+    expect(() =>
+      assertNotFlagLike("--post-renderer=/tmp/x.sh", "release name")
     ).not.toThrow();
   });
 });


### PR DESCRIPTION
## What

`install_helm_chart`, `upgrade_helm_chart` and `uninstall_helm_chart` place caller-supplied values — release name, chart, namespace, repo — directly into positional argv slots (`helm install <name> <chart>`, `helm repo add <name> <url>`, `kubectl create namespace <ns>`). pflag parses any token beginning with `-` as a flag regardless of position, so those operands could arrive shaped like flags and be parsed as such.

`assertSafeArgv()` is a deny-list, so it only refuses flag names it already knows about; every flag it doesn't list is reachable through any positional slot. This closes the injection point instead of chasing the list:

- **`assertNotFlagLike(value, field)`** in `src/security/kubectl-flags.ts` — refuses a caller-supplied operand that starts with `-`. None of these values is ever legitimately flag-shaped (helm release names and namespaces are RFC 1123 names; chart references are repo/name pairs, paths or URLs), so this has no effect on valid input. It honours the same `ALLOW_KUBECTL_UNSAFE_FLAGS` escape hatch as the existing guard.
- Wired into all three helm entry points, next to `rejectValuesFileOnRemoteTransport()` — i.e. **before** the `try`/`catch`, so a bad operand surfaces as an `InvalidParams` error instead of being folded into a `{"status":"failed"}` result.
- Defense in depth: added `--post-renderer`, `--post-renderer-args`, `--repository-config` and `--registry-config` to the helm deny-list. These act on the machine running the MCP server rather than on the cluster, which is the same boundary `rejectValuesFileOnRemoteTransport()` already defends, and no tool here has any reason to emit them.

## Tests

- `tests/helm-argument-injection.unit.test.ts` (new) — each helm tool refuses flag-shaped `name`/`chart`/`namespace`/`repo` before spawning anything, with an `InvalidParams` `McpError`.
- `tests/kubectl-flags-security.unit.test.ts` — coverage for `assertNotFlagLike` (including that ordinary names, chart paths and repo URLs still pass, and that the escape hatch works) and for the newly denied helm flags in both `-` and `_` spellings.

All unit suites pass (`120 passed`); verified end to end against helm 3.17.1 that an affected argument is now refused before helm runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128PberJYFm2m4DWXkFdpd7