### PR TITLE
Exclude all-interfaces bind addresses from the Host allowlist

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -301,7 +301,9 @@ DNS rebinding protection is **enabled by default** to prevent malicious web page
 - `127.0.0.1`, `127.0.0.1:<PORT>`
 - `localhost`, `localhost:<PORT>`
 - `::1`, `[::1]:<PORT>`
-- The configured `HOST` value (and `HOST:PORT`) when it differs from the above
+- The configured `HOST` value (and `HOST:PORT`) when it differs from the above and names a specific interface
+
+All-interfaces bind addresses (`0.0.0.0`, `::`) are **not** added to the allowlist: they are bind directives rather than hostnames a client resolves, so accepting one as a `Host` header would let any caller that can reach the port satisfy the allowlist. When you bind to all interfaces, name the hostname clients actually use via `DNS_REBINDING_ALLOWED_HOST` (see below); the server prints a startup note reminding you. Localhost callers — including `kubectl port-forward` — keep working with no extra configuration.
 
 Local usage requires no extra flags:
 
@@ -334,6 +336,10 @@ DNS_REBINDING_PROTECTION=false ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=1 PORT=30
 ```
 
 The server prints a startup warning when protection is disabled while binding to `0.0.0.0` or `::`, since that combination is the most common foot-gun.
+
+##### Deploying with the Helm chart
+
+The Helm chart's `http` / `sse` transport modes bind the pod to all interfaces, so in-cluster clients reach the server under its Service hostname. Set `DNS_REBINDING_ALLOWED_HOST` to that hostname (e.g. `<release>-mcp-server-kubernetes.<namespace>.svc.cluster.local:<port>`, matching what your clients send) and set `security.mcpAuthToken` so requests are authenticated — the `Host` check is not an authentication mechanism.
 
 ### SSE Transport (Deprecated in favor of Streamable HTTP)
 

--- a/src/utils/allowed-hosts.ts
+++ b/src/utils/allowed-hosts.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared construction of the allowedHosts list used by both HTTP transports
+ * for DNS rebinding protection.
+ */
+
+// Bind addresses that mean "every interface". They are not hostnames: no
+// legitimate client resolves them, so no legitimate client sends one in a Host
+// header. See isAllInterfacesHost / buildDefaultAllowedHosts below.
+const ALL_INTERFACES_HOSTS = new Set<string>(["0.0.0.0", "::", "::0", "0"]);
+
+/**
+ * True when `host` is an all-interfaces bind address ("0.0.0.0", "::", and the
+ * bracketed IPv6 spelling).
+ */
+export function isAllInterfacesHost(host: string): boolean {
+  const bare = host.startsWith("[") && host.endsWith("]")
+    ? host.slice(1, -1)
+    : host;
+  return ALL_INTERFACES_HOSTS.has(bare);
+}
+
+/**
+ * Build the default allowedHosts list for DNS rebinding protection.
+ * Includes localhost variants with and without port.
+ *
+ * The configured HOST is added too, so that binding to a specific address also
+ * accepts that address as a Host header — but only when it names an actual
+ * interface. An all-interfaces bind ("0.0.0.0", "::") is deliberately excluded:
+ * it is a bind directive, not an address a client resolves, so accepting it
+ * would let any caller satisfy the allowlist by sending "Host: 0.0.0.0:<port>"
+ * — a value that is public knowledge rather than a property of the deployment.
+ * That would defeat the guard exactly where it matters most, since binding to
+ * all interfaces is what makes the server reachable off-host in the first
+ * place.
+ *
+ * Deployments that bind to all interfaces and need to accept a real hostname
+ * (a Kubernetes Service DNS name, an ingress host) set
+ * DNS_REBINDING_ALLOWED_HOST to that name; it replaces this list entirely.
+ */
+export function buildDefaultAllowedHosts(host: string, port: number): string[] {
+  // Always allow the bare host and host:port for common localhost addresses
+  const localhostAliases = ["127.0.0.1", "localhost", "::1"];
+  const hosts: string[] = [];
+  for (const alias of localhostAliases) {
+    hosts.push(alias);
+    // HTTP Host header uses bracket notation for IPv6: [::1]:3000
+    if (alias.includes(":")) {
+      hosts.push(`[${alias}]`);
+      hosts.push(`[${alias}]:${port}`);
+    } else {
+      hosts.push(`${alias}:${port}`);
+    }
+  }
+  // Also add the configured host if it's not already covered, unless it is an
+  // all-interfaces bind address (see above).
+  if (!localhostAliases.includes(host) && !isAllInterfacesHost(host)) {
+    hosts.push(host);
+    if (host.includes(":") && !host.startsWith("[")) {
+      hosts.push(`[${host}]`);
+      hosts.push(`[${host}]:${port}`);
+    } else {
+      hosts.push(`${host}:${port}`);
+    }
+  }
+  return hosts;
+}

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -2,37 +2,10 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import express from "express";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { createAuthMiddleware, isAuthEnabled } from "./auth.js";
-
-/**
- * Build the default allowedHosts list for DNS rebinding protection.
- * Includes localhost variants with and without port.
- */
-function buildDefaultAllowedHosts(host: string, port: number): string[] {
-  // Always allow the bare host and host:port for common localhost addresses
-  const localhostAliases = ["127.0.0.1", "localhost", "::1"];
-  const hosts: string[] = [];
-  for (const alias of localhostAliases) {
-    hosts.push(alias);
-    // HTTP Host header uses bracket notation for IPv6: [::1]:3000
-    if (alias.includes(":")) {
-      hosts.push(`[${alias}]`);
-      hosts.push(`[${alias}]:${port}`);
-    } else {
-      hosts.push(`${alias}:${port}`);
-    }
-  }
-  // Also add the configured host if it's not already covered
-  if (!localhostAliases.includes(host)) {
-    hosts.push(host);
-    if (host.includes(":") && !host.startsWith("[")) {
-      hosts.push(`[${host}]`);
-      hosts.push(`[${host}]:${port}`);
-    } else {
-      hosts.push(`${host}:${port}`);
-    }
-  }
-  return hosts;
-}
+import {
+  buildDefaultAllowedHosts,
+  isAllInterfacesHost,
+} from "./allowed-hosts.js";
 
 export function startSSEServer(server: Server) {
   const app = express();
@@ -54,12 +27,29 @@ export function startSSEServer(server: Server) {
     : buildDefaultAllowedHosts(host, port);
 
   // Warn when binding to all interfaces with DNS rebinding protection disabled
-  if (!enableDnsRebindingProtection && (host === "0.0.0.0" || host === "::")) {
+  if (!enableDnsRebindingProtection && isAllInterfacesHost(host)) {
     console.warn(
       "WARNING: DNS rebinding protection is disabled while HOST is set to " +
         `'${host}'. This exposes the MCP server to DNS rebinding attacks ` +
         "from any browser on the network. Set DNS_REBINDING_PROTECTION=true " +
         "(the default) or restrict HOST to 'localhost' / '127.0.0.1'."
+    );
+  }
+
+  // Binding to all interfaces makes the server reachable off-host, but the
+  // default allowlist only covers localhost: a client reaching it under any
+  // other name gets a 403 until the operator names that hostname explicitly.
+  if (
+    enableDnsRebindingProtection &&
+    isAllInterfacesHost(host) &&
+    !process.env.DNS_REBINDING_ALLOWED_HOST
+  ) {
+    console.warn(
+      `NOTE: HOST is set to '${host}' (all interfaces) and DNS rebinding ` +
+        "protection is enabled, so only requests with a localhost Host header " +
+        "are accepted. Clients reaching this server under another hostname " +
+        "(a Kubernetes Service name, an ingress host) must be allowed by " +
+        "setting DNS_REBINDING_ALLOWED_HOST to that hostname."
     );
   }
 
@@ -112,9 +102,14 @@ export function startSSEServer(server: Server) {
     }
   });
 
+  // An all-interfaces bind is not a hostname a client can use: with DNS
+  // rebinding protection on it is not in the allowlist either, so advertise a
+  // localhost URL that actually works rather than 'http://0.0.0.0:<port>'.
+  const advertisedHost = isAllInterfacesHost(host) ? "localhost" : host;
+
   app.listen(port, host, () => {
     console.log(
-      `mcp-kubernetes-server is listening on port ${port}\nUse the following url to connect to the server:\nhttp://${host}:${port}/sse`
+      `mcp-kubernetes-server is listening on port ${port}\nUse the following url to connect to the server:\nhttp://${advertisedHost}:${port}/sse`
     );
     if (isAuthEnabled()) {
       console.log(

--- a/src/utils/streamable-http.ts
+++ b/src/utils/streamable-http.ts
@@ -3,37 +3,10 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import http from "http";
 import { createAuthMiddleware, isAuthEnabled } from "./auth.js";
-
-/**
- * Build the default allowedHosts list for DNS rebinding protection.
- * Includes localhost variants with and without port.
- */
-function buildDefaultAllowedHosts(host: string, port: number): string[] {
-  // Always allow the bare host and host:port for common localhost addresses
-  const localhostAliases = ["127.0.0.1", "localhost", "::1"];
-  const hosts: string[] = [];
-  for (const alias of localhostAliases) {
-    hosts.push(alias);
-    // HTTP Host header uses bracket notation for IPv6: [::1]:3000
-    if (alias.includes(":")) {
-      hosts.push(`[${alias}]`);
-      hosts.push(`[${alias}]:${port}`);
-    } else {
-      hosts.push(`${alias}:${port}`);
-    }
-  }
-  // Also add the configured host if it's not already covered
-  if (!localhostAliases.includes(host)) {
-    hosts.push(host);
-    if (host.includes(":") && !host.startsWith("[")) {
-      hosts.push(`[${host}]`);
-      hosts.push(`[${host}]:${port}`);
-    } else {
-      hosts.push(`${host}:${port}`);
-    }
-  }
-  return hosts;
-}
+import {
+  buildDefaultAllowedHosts,
+  isAllInterfacesHost,
+} from "./allowed-hosts.js";
 
 export function startStreamableHTTPServer(server: Server): http.Server {
   const app = express();
@@ -56,12 +29,29 @@ export function startStreamableHTTPServer(server: Server): http.Server {
     : buildDefaultAllowedHosts(host, port);
 
   // Warn when binding to all interfaces with DNS rebinding protection disabled
-  if (!enableDnsRebindingProtection && (host === "0.0.0.0" || host === "::")) {
+  if (!enableDnsRebindingProtection && isAllInterfacesHost(host)) {
     console.warn(
       "WARNING: DNS rebinding protection is disabled while HOST is set to " +
         `'${host}'. This exposes the MCP server to DNS rebinding attacks ` +
         "from any browser on the network. Set DNS_REBINDING_PROTECTION=true " +
         "(the default) or restrict HOST to 'localhost' / '127.0.0.1'."
+    );
+  }
+
+  // Binding to all interfaces makes the server reachable off-host, but the
+  // default allowlist only covers localhost: a client reaching it under any
+  // other name gets a 403 until the operator names that hostname explicitly.
+  if (
+    enableDnsRebindingProtection &&
+    isAllInterfacesHost(host) &&
+    !process.env.DNS_REBINDING_ALLOWED_HOST
+  ) {
+    console.warn(
+      `NOTE: HOST is set to '${host}' (all interfaces) and DNS rebinding ` +
+        "protection is enabled, so only requests with a localhost Host header " +
+        "are accepted. Clients reaching this server under another hostname " +
+        "(a Kubernetes Service name, an ingress host) must be allowed by " +
+        "setting DNS_REBINDING_ALLOWED_HOST to that hostname."
     );
   }
 
@@ -153,9 +143,14 @@ export function startStreamableHTTPServer(server: Server): http.Server {
     }
   });
 
+  // An all-interfaces bind is not a hostname a client can use: with DNS
+  // rebinding protection on it is not in the allowlist either, so advertise a
+  // localhost URL that actually works rather than 'http://0.0.0.0:<port>'.
+  const advertisedHost = isAllInterfacesHost(host) ? "localhost" : host;
+
   const httpServer = app.listen(port, host, () => {
     console.log(
-      `mcp-kubernetes-server is listening on port ${port}\nUse the following url to connect to the server:\nhttp://${host}:${port}/mcp`
+      `mcp-kubernetes-server is listening on port ${port}\nUse the following url to connect to the server:\nhttp://${advertisedHost}:${port}/mcp`
     );
     if (isAuthEnabled()) {
       console.log(

--- a/tests/allowed-hosts.unit.test.ts
+++ b/tests/allowed-hosts.unit.test.ts
@@ -1,0 +1,67 @@
+import { expect, test, describe } from "vitest";
+import {
+  buildDefaultAllowedHosts,
+  isAllInterfacesHost,
+} from "../src/utils/allowed-hosts.js";
+
+describe("isAllInterfacesHost", () => {
+  test("recognises the all-interfaces bind addresses", () => {
+    expect(isAllInterfacesHost("0.0.0.0")).toBe(true);
+    expect(isAllInterfacesHost("::")).toBe(true);
+    expect(isAllInterfacesHost("[::]")).toBe(true);
+    expect(isAllInterfacesHost("::0")).toBe(true);
+  });
+
+  test("does not treat real addresses or hostnames as all-interfaces", () => {
+    expect(isAllInterfacesHost("localhost")).toBe(false);
+    expect(isAllInterfacesHost("127.0.0.1")).toBe(false);
+    expect(isAllInterfacesHost("10.0.0.5")).toBe(false);
+    expect(isAllInterfacesHost("mcp.svc.cluster.local")).toBe(false);
+    // Not a wildcard bind: an address that merely starts with a zero octet.
+    expect(isAllInterfacesHost("0.0.0.1")).toBe(false);
+  });
+});
+
+describe("buildDefaultAllowedHosts", () => {
+  test("always covers the localhost aliases with and without port", () => {
+    const hosts = buildDefaultAllowedHosts("localhost", 3000);
+    for (const expected of [
+      "localhost",
+      "localhost:3000",
+      "127.0.0.1",
+      "127.0.0.1:3000",
+      "::1",
+      "[::1]",
+      "[::1]:3000",
+    ]) {
+      expect(hosts).toContain(expected);
+    }
+  });
+
+  test("includes a specific configured host, which names a real interface", () => {
+    const hosts = buildDefaultAllowedHosts("10.0.0.5", 3000);
+    expect(hosts).toContain("10.0.0.5");
+    expect(hosts).toContain("10.0.0.5:3000");
+  });
+
+  test("excludes all-interfaces binds: they are not a client-presentable name", () => {
+    // "Host: 0.0.0.0:3000" is public knowledge, not a property of the
+    // deployment, so accepting it would let any caller satisfy the allowlist.
+    const v4 = buildDefaultAllowedHosts("0.0.0.0", 3000);
+    expect(v4).not.toContain("0.0.0.0");
+    expect(v4).not.toContain("0.0.0.0:3000");
+
+    const v6 = buildDefaultAllowedHosts("::", 3000);
+    expect(v6).not.toContain("::");
+    expect(v6).not.toContain("[::]");
+    expect(v6).not.toContain("[::]:3000");
+  });
+
+  test("localhost access still works when bound to all interfaces", () => {
+    // kubectl port-forward / local curl send a localhost Host header, so those
+    // workflows are unaffected by the exclusion above.
+    const hosts = buildDefaultAllowedHosts("0.0.0.0", 3000);
+    expect(hosts).toContain("localhost:3000");
+    expect(hosts).toContain("127.0.0.1:3000");
+  });
+});

--- a/tests/dns-rebinding.test.ts
+++ b/tests/dns-rebinding.test.ts
@@ -203,3 +203,101 @@ describe("DNS Rebinding Protection - warning on 0.0.0.0 without protection", () 
     }
   });
 });
+
+// An all-interfaces bind is a bind directive, not a hostname any client
+// resolves. Accepting it as a Host header would let any caller that can reach
+// the port satisfy the allowlist by sending "Host: 0.0.0.0:<port>" — a value
+// that is public knowledge rather than a property of the deployment.
+describe("DNS Rebinding Protection - HOST bound to all interfaces", () => {
+  let httpServer: http.Server;
+  let port: number;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeAll(async () => {
+    savedEnv = saveEnvKeys(ENV_KEYS);
+    port = await findAvailablePort(5300);
+    process.env.PORT = port.toString();
+    process.env.HOST = "0.0.0.0";
+    // Protection left at its default (enabled)
+
+    const server = new Server(
+      { name: "test-dns-all-interfaces", version: "1.0.0" },
+      { capabilities: { tools: {} } }
+    );
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
+      return { tools: [pingSchema] };
+    });
+    httpServer = startStreamableHTTPServer(server);
+    await waitForListening(httpServer);
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((err) => (err ? reject(err) : resolve()));
+    });
+    restoreEnvKeys(savedEnv);
+  });
+
+  test("should reject a request whose Host header is the bind address", async () => {
+    const res = await mcpPost(port, makeListToolsRequest(4), `0.0.0.0:${port}`);
+    expect(res.status).toBe(403);
+  });
+
+  test("should still reject a foreign Host header", async () => {
+    const res = await mcpPost(port, makeListToolsRequest(5), "evil.attacker.com");
+    expect(res.status).toBe(403);
+  });
+
+  test("should still allow localhost callers (port-forward, local curl)", async () => {
+    const res = await mcpPost(port, makeListToolsRequest(6), `127.0.0.1:${port}`);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("DNS Rebinding Protection - all-interfaces bind advises the escape hatch", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeAll(async () => {
+    savedEnv = saveEnvKeys(ENV_KEYS);
+  });
+
+  afterAll(async () => {
+    restoreEnvKeys(savedEnv);
+  });
+
+  test("names DNS_REBINDING_ALLOWED_HOST when bound to 0.0.0.0 with protection on", async () => {
+    const port = await findAvailablePort(5400);
+    process.env.PORT = port.toString();
+    process.env.HOST = "0.0.0.0";
+
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...args: any[]) => {
+      warnings.push(args.join(" "));
+    };
+
+    let hs: http.Server | undefined;
+    try {
+      const server = new Server(
+        { name: "test-dns-hint", version: "1.0.0" },
+        { capabilities: { tools: {} } }
+      );
+      server.setRequestHandler(ListToolsRequestSchema, async () => {
+        return { tools: [pingSchema] };
+      });
+      hs = startStreamableHTTPServer(server);
+      await waitForListening(hs);
+
+      expect(
+        warnings.some((w) => w.includes("DNS_REBINDING_ALLOWED_HOST"))
+      ).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+      if (hs) {
+        await new Promise<void>((resolve, reject) => {
+          hs!.close((err) => (err ? reject(err) : resolve()));
+        });
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

`buildDefaultAllowedHosts()` added the configured `HOST` to the DNS-rebinding allowlist unconditionally. When `HOST` is an all-interfaces bind (`0.0.0.0`, `::`), that value isn't a hostname any client resolves — it's a bind directive, and a publicly known one — so it let any caller that could reach the port satisfy the allowlist by sending `Host: 0.0.0.0:<port>`. The guard was then only constraining callers who present an honest hostname; the ones it exists to stop could opt out of it.

This excludes all-interfaces binds from the default allowlist. Nothing else about the guard changes.

## Compatibility

- **Localhost callers are unaffected.** The localhost aliases stay in the list, so local `curl` and `kubectl port-forward` keep working when the server binds to `0.0.0.0`.
- **Clients reaching the server under a real hostname** (Service DNS name, ingress host) set `DNS_REBINDING_ALLOWED_HOST` — already the documented path for this in `ADVANCED_README.md`. Those clients were getting a `403` before this change too, since their hostname was never in the default list; the only thing that stops working is `Host: 0.0.0.0`, which no legitimate client sends.
- No Helm chart defaults are touched.

Two related touches while in here:
- A startup note when binding to all interfaces with protection on and no `DNS_REBINDING_ALLOWED_HOST`, so the 403 an operator would otherwise hit is explained up front.
- The startup banner advertised `http://0.0.0.0:<port>/mcp`, a URL the allowlist now rejects. It prints the localhost URL instead when bound to all interfaces.

The allowlist builder was duplicated verbatim in `streamable-http.ts` and `sse.ts`; it now lives in `src/utils/allowed-hosts.ts` and both import it, so the two transports can't drift.

## Tests

- `tests/allowed-hosts.unit.test.ts` (new) — the builder's contract: localhost aliases always present, a specific configured host still included, all-interfaces binds excluded in both v4 and v6 spellings, localhost access preserved under a wildcard bind.
- `tests/dns-rebinding.test.ts` — end-to-end with `HOST=0.0.0.0` and protection at its default: `Host: 0.0.0.0:<port>` gets `403`, a foreign Host still gets `403`, `127.0.0.1:<port>` still gets `200`, and the startup note names `DNS_REBINDING_ALLOWED_HOST`.

Verified against a real build with the env combination the chart produces (`ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT=true HOST=0.0.0.0`): before, an unauthenticated `tools/list` with `Host: 0.0.0.0:<port>` returned the full tool list; after, `403 Invalid Host header`, while `Host: localhost:<port>` still returns `200`. All 128 tests in the affected suites pass.

## Note

The `Host` check is not authentication, and this doesn't make an unauthenticated HTTP deployment safe — `security.mcpAuthToken` still needs to be set for that. This only makes the shipped control do the job it claims to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128PberJYFm2m4DWXkFdpd7