### PR TITLE
Harden argv construction: flag-shaped operands and server-side file reads

### DIFF
--- a/src/security/kubectl-flags.ts
+++ b/src/security/kubectl-flags.ts
@@ -146,13 +146,17 @@ const FILE_READ_SHORT_FLAGS = new Set<string>([
   "k", // --kustomize
 ]);
 
-// Output formats that take a file path as their argument: "-o
-// go-template-file=/etc/passwd" makes kubectl read and render that file, which
-// is the same server-side read primitive as --from-file wearing a different
-// flag name.
+// Output formats whose argument is a file path on the machine kubectl runs on:
+// "-o go-template-file=<path>" makes kubectl read that file and render it into
+// the result. That is the same read as --from-file under a different flag
+// name, but unlike --from-file no tool here ever legitimately emits one — so
+// assertSafeArgv refuses them in any argv, on any transport, rather than only
+// where a server-side path would be attacker-chosen. Every tool has positional
+// slots, read-only ones included, so a name-shaped denial is not enough.
 const FILE_READ_OUTPUT_FORMATS = new Set<string>([
   "go-template-file",
   "jsonpath-file",
+  "custom-columns-file",
 ]);
 
 function isUnsafeFlagsAllowed(): boolean {
@@ -275,7 +279,8 @@ export function assertNoDangerousFlags(
 export function assertSafeArgv(args: readonly string[]): void {
   if (isUnsafeFlagsAllowed()) return;
 
-  for (const tok of args) {
+  for (let i = 0; i < args.length; i++) {
+    const tok = args[i];
     if (typeof tok !== "string") continue;
     if (!tok.startsWith("-")) continue;
     const name = normalizeFlagName(tok);
@@ -284,6 +289,16 @@ export function assertSafeArgv(args: readonly string[]): void {
     // match every letter pflag would parse out of the cluster, not just the
     // first one.
     if (hasDangerousShortFlag(tok)) reject(tok);
+    // A file read hiding in the *value* of an otherwise ordinary flag
+    // ("-o go-template-file=<path>"), so it has to be matched on the value
+    // rather than on the flag name.
+    const format = outputFormatValue(tok, args[i + 1]);
+    if (
+      format !== undefined &&
+      FILE_READ_OUTPUT_FORMATS.has(format.split("=")[0])
+    ) {
+      rejectOutputFileRead(tok, format);
+    }
   }
 }
 
@@ -314,6 +329,18 @@ function outputFormatValue(
   let rest = tok.slice(1 + idx + 1);
   if (rest.startsWith("=")) rest = rest.slice(1);
   return rest === "" ? next : rest;
+}
+
+function rejectOutputFileRead(tok: string, format: string): never {
+  throw new McpError(
+    ErrorCode.InvalidParams,
+    `Refusing to run kubectl with "${tok} ${format}": this output format ` +
+      `takes a file path and makes kubectl read that file from the MCP ` +
+      `server's own filesystem, rendering it into the result. No tool needs ` +
+      `it, and a resource name or type that parses as this flag is an ` +
+      `injection attempt. Use an inline template ("-o go-template=...") or a ` +
+      `jsonpath expression instead.`
+  );
 }
 
 function rejectFileRead(flag: string): never {
@@ -364,32 +391,23 @@ export function assertNoRemoteFileReads(args: readonly string[]): void {
     if (letters?.some((letter) => FILE_READ_SHORT_FLAGS.has(letter))) {
       rejectFileRead(tok);
     }
-
-    // "-o go-template-file=/etc/passwd" is the same read primitive wearing a
-    // different flag name.
-    const format = outputFormatValue(tok, args[i + 1]);
-    if (
-      format !== undefined &&
-      FILE_READ_OUTPUT_FORMATS.has(format.split("=")[0])
-    ) {
-      rejectFileRead(`${tok} ${format}`.trim());
-    }
   }
 }
 
 /**
  * Reject a caller-supplied value that a tool is about to place in a *positional*
- * argv slot (a release name, a chart reference, a namespace) when it is shaped
- * like a command-line flag.
+ * argv slot (a resource type, a resource name, a release name, a chart
+ * reference, a namespace) when it is shaped like a command-line flag.
  *
  * assertSafeArgv is a deny-list: it can only refuse the flags it knows about,
  * so every dangerous flag added upstream is exploitable through any positional
  * slot until the list is extended. This guard closes the injection point
  * instead of chasing the flags: pflag treats any token starting with "-" as a
  * flag no matter where it sits, and none of these operands is ever legitimately
- * flag-shaped (helm release names and namespaces are RFC 1123 names; chart
- * references are repo/name pairs, paths or URLs). Refusing a leading "-" here
- * means caller data can never occupy a slot where it would be parsed as a flag.
+ * flag-shaped (Kubernetes resource types and names, helm release names and
+ * namespaces are RFC 1123 names; chart references are repo/name pairs, paths
+ * or URLs). Refusing a leading "-" here means caller data can never occupy a
+ * slot where it would be parsed as a flag.
  *
  * Honours the same ALLOW_KUBECTL_UNSAFE_FLAGS escape hatch as the flag guard.
  */
@@ -402,10 +420,10 @@ export function assertNotFlagLike(
 
   throw new McpError(
     ErrorCode.InvalidParams,
-    `Refusing to run helm with ${field}="${value}": a value starting with ` +
-      `"-" is parsed as a command-line flag rather than as the ${field}, ` +
-      `which would let the caller inject arbitrary helm flags. Provide a ` +
-      `${field} that does not begin with "-".`
+    `Refusing to run kubectl/helm with ${field}="${value}": a value ` +
+      `starting with "-" is parsed as a command-line flag rather than as ` +
+      `the ${field}, which would let the caller inject arbitrary flags. ` +
+      `Provide a ${field} that does not begin with "-".`
   );
 }
 

--- a/src/security/kubectl-flags.ts
+++ b/src/security/kubectl-flags.ts
@@ -3,6 +3,7 @@ import {
   execFileSync,
   type ExecFileSyncOptionsWithStringEncoding,
 } from "child_process";
+import { isRemoteTransport } from "./transport.js";
 
 // Flags that would let a caller redirect kubectl to a different API server,
 // substitute credentials, or impersonate another identity. Allowing any of
@@ -118,6 +119,41 @@ const ARGV_DANGEROUS_FLAGS = new Set<string>(
     (name) => name !== "context"
   )
 );
+
+// Flags that make kubectl read a file from the machine it is running on.
+//
+// These are not in DANGEROUS_FLAGS: under stdio that machine is the operator's
+// own, and "-f manifest.yaml" is the whole point of the tool. They only become
+// a vulnerability on a remote (SSE / Streamable HTTP) transport, where the path
+// is chosen by a client but resolved on the server host — so they are rejected
+// by transport, in assertNoRemoteFileReads, rather than denied outright.
+//
+// Long names only; the single-dash spellings live in FILE_READ_SHORT_FLAGS.
+const FILE_READ_FLAGS = new Set<string>([
+  "filename",
+  "from-file",
+  "from-env-file",
+  "kustomize",
+  "patch-file",
+]);
+
+// Single-letter spellings of the above. Unlike SHORT_ALIASES these are checked
+// against every letter pflag would parse out of a shorthand cluster, so the
+// attached ("-f/etc/passwd") and clustered ("-Rf/etc/passwd") forms are caught
+// alongside the split one ("-f", "/etc/passwd").
+const FILE_READ_SHORT_FLAGS = new Set<string>([
+  "f", // --filename
+  "k", // --kustomize
+]);
+
+// Output formats that take a file path as their argument: "-o
+// go-template-file=/etc/passwd" makes kubectl read and render that file, which
+// is the same server-side read primitive as --from-file wearing a different
+// flag name.
+const FILE_READ_OUTPUT_FORMATS = new Set<string>([
+  "go-template-file",
+  "jsonpath-file",
+]);
 
 function isUnsafeFlagsAllowed(): boolean {
   return process.env.ALLOW_KUBECTL_UNSAFE_FLAGS === "true";
@@ -248,6 +284,96 @@ export function assertSafeArgv(args: readonly string[]): void {
     // match every letter pflag would parse out of the cluster, not just the
     // first one.
     if (hasDangerousShortFlag(tok)) reject(tok);
+  }
+}
+
+/**
+ * Return the value kubectl would take for -o / --output in `tok`, or undefined
+ * if `tok` is not an output flag. The value may be attached to the token
+ * ("-ojson", "-o=json", "--output=json") or sit in the following one, which is
+ * why the caller passes `next`.
+ */
+function outputFormatValue(
+  tok: string,
+  next: string | undefined
+): string | undefined {
+  if (tok.startsWith("--")) {
+    if (normalizeFlagName(tok) !== "output") return undefined;
+    const eq = tok.indexOf("=");
+    return eq === -1 ? next : tok.slice(eq + 1);
+  }
+
+  const letters = shortFlagLetters(tok);
+  if (letters === null) return undefined;
+  const idx = letters.indexOf("o");
+  if (idx === -1) return undefined;
+
+  // "o" takes a value, so pflag stops the cluster there and reads the rest of
+  // the token as the format ("-Aojson" -> "-A -o json"). An empty remainder
+  // means the format is the next argv token instead.
+  let rest = tok.slice(1 + idx + 1);
+  if (rest.startsWith("=")) rest = rest.slice(1);
+  return rest === "" ? next : rest;
+}
+
+function rejectFileRead(flag: string): never {
+  throw new McpError(
+    ErrorCode.InvalidParams,
+    `Refusing to run kubectl with "${flag}": this flag reads a file from the ` +
+      `MCP server's own filesystem, which is disabled on remote (SSE/` +
+      `Streamable HTTP) transports because the path is chosen by the client ` +
+      `but resolved on the server host. Pass the file contents inline ` +
+      `instead (kubectl_apply/kubectl_create "manifest", kubectl_create ` +
+      `"fromFileContent", or install_helm_chart "values").`
+  );
+}
+
+/**
+ * Reject flags that make kubectl read a file from the MCP server's filesystem,
+ * on remote transports only. No-op under stdio.
+ *
+ * kubectl_generic lets a caller assemble an arbitrary kubectl argv, so the
+ * per-parameter guards the structured tools use (`filename`, `fromFile`,
+ * `patchFile`, `valuesFile`) have nothing to attach to: the same read is
+ * reachable as a raw "--from-file=leak=/etc/passwd" token. Under stdio that is
+ * the operator reading their own files and stays allowed; over SSE/Streamable
+ * HTTP the path comes from whoever can reach the endpoint but resolves on the
+ * server host, turning kubectl into an arbitrary file-read oracle (kubeconfig,
+ * service-account token, /proc/self/environ) — with --dry-run=client, without
+ * even a cluster.
+ *
+ * Takes a fully-constructed argv rather than the `flags`/`args` inputs so that
+ * flags built from the object form and file-shaped values smuggled through
+ * positional slots (resourceType, name) are covered by the same scan. Unlike
+ * assertNoDangerousFlags there is no ALLOW_KUBECTL_UNSAFE_FLAGS escape hatch:
+ * this mirrors the transport guards in the structured tools, which reject
+ * server-side paths unconditionally.
+ */
+export function assertNoRemoteFileReads(args: readonly string[]): void {
+  if (!isRemoteTransport()) return;
+
+  for (let i = 0; i < args.length; i++) {
+    const tok = args[i];
+    if (typeof tok !== "string" || !tok.startsWith("-")) continue;
+
+    if (FILE_READ_FLAGS.has(normalizeFlagName(tok))) rejectFileRead(tok);
+
+    // Short spellings, including the attached and clustered forms pflag
+    // accepts: "-f/etc/passwd", "-Rf/etc/passwd".
+    const letters = shortFlagLetters(tok);
+    if (letters?.some((letter) => FILE_READ_SHORT_FLAGS.has(letter))) {
+      rejectFileRead(tok);
+    }
+
+    // "-o go-template-file=/etc/passwd" is the same read primitive wearing a
+    // different flag name.
+    const format = outputFormatValue(tok, args[i + 1]);
+    if (
+      format !== undefined &&
+      FILE_READ_OUTPUT_FORMATS.has(format.split("=")[0])
+    ) {
+      rejectFileRead(`${tok} ${format}`.trim());
+    }
   }
 }
 

--- a/src/tools/kubectl-delete.ts
+++ b/src/tools/kubectl-delete.ts
@@ -1,5 +1,8 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSyncSafe } from "../security/kubectl-flags.js";
+import {
+  assertNotFlagLike,
+  execFileSyncSafe,
+} from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import * as fs from "fs";
 import * as path from "path";
@@ -132,6 +135,12 @@ export async function kubectlDelete(
       args.push("-f", input.filename);
     } else {
       // Handle deleting by resource type and name/selector
+      // A resource type or name is an RFC 1123 name, never a flag. Refusing
+      // a leading "-" closes the positional injection slot itself rather than
+      // relying on the argv denylist to know every dangerous flag.
+      assertNotFlagLike(input.resourceType, "resourceType");
+      assertNotFlagLike(input.name, "name");
+
       args.push(input.resourceType!);
 
       if (input.name) {

--- a/src/tools/kubectl-describe.ts
+++ b/src/tools/kubectl-describe.ts
@@ -1,5 +1,8 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSyncSafe } from "../security/kubectl-flags.js";
+import {
+  assertNotFlagLike,
+  execFileSyncSafe,
+} from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import {
@@ -49,6 +52,12 @@ export async function kubectlDescribe(
   }
 ) {
   try {
+    // A resource type or name is an RFC 1123 name, never a flag. Refusing a
+    // leading "-" closes the positional injection slot itself rather than
+    // relying on the argv denylist to know every dangerous flag.
+    assertNotFlagLike(input.resourceType, "resourceType");
+    assertNotFlagLike(input.name, "name");
+
     const resourceType = input.resourceType.toLowerCase();
     const name = input.name;
     const namespace = input.namespace || "default";

--- a/src/tools/kubectl-generic.ts
+++ b/src/tools/kubectl-generic.ts
@@ -9,6 +9,7 @@ import {
 import {
   assertNoDangerousFlags,
   assertNoRemoteFileReads,
+  assertNotFlagLike,
 } from "../security/kubectl-flags.js";
 
 export const kubectlGenericSchema = {
@@ -85,6 +86,14 @@ export async function kubectlGeneric(
     // command. See src/security/kubectl-flags.ts for the rationale.
     assertNoDangerousFlags(input.flags, input.args);
 
+    // The verb and the resource operands are never flags — only the free-form
+    // `args` array is. Refusing a leading "-" in the operand slots closes the
+    // positional injection point without narrowing what `args` can express.
+    assertNotFlagLike(input.command, "command");
+    assertNotFlagLike(input.subCommand, "subCommand");
+    assertNotFlagLike(input.resourceType, "resourceType");
+    assertNotFlagLike(input.name, "name");
+
     // Start building the kubectl command
     const command = "kubectl";
     const cmdArgs: string[] = [input.command];
@@ -140,11 +149,11 @@ export async function kubectlGeneric(
       cmdArgs.push("--context", input.context);
     }
 
-    // Reject server-side filesystem reads on remote transports. This tool
-    // hands the caller a free-form kubectl argv, so the per-parameter guards
-    // the structured tools use have nothing to attach to: "--from-file",
-    // "-f" and friends arrive as raw tokens. See GHSA-m67f-jxm9-cvx8 for the
-    // read primitive and src/security/kubectl-flags.ts for the flag list.
+    // Reject server-side filesystem reads on remote transports, matching the
+    // per-parameter guards in the structured tools. This tool hands the caller
+    // a free-form kubectl argv, so there is no parameter to attach them to:
+    // "--from-file", "-f" and friends arrive as raw tokens and have to be
+    // matched in the argv. See src/security/transport.ts for the trust model.
     // No-op under stdio, where the files are the operator's own.
     assertNoRemoteFileReads(cmdArgs);
 

--- a/src/tools/kubectl-generic.ts
+++ b/src/tools/kubectl-generic.ts
@@ -6,7 +6,10 @@ import {
   contextParameter,
   namespaceParameter,
 } from "../models/common-parameters.js";
-import { assertNoDangerousFlags } from "../security/kubectl-flags.js";
+import {
+  assertNoDangerousFlags,
+  assertNoRemoteFileReads,
+} from "../security/kubectl-flags.js";
 
 export const kubectlGenericSchema = {
   name: "kubectl_generic",
@@ -136,6 +139,14 @@ export async function kubectlGeneric(
     if (input.context) {
       cmdArgs.push("--context", input.context);
     }
+
+    // Reject server-side filesystem reads on remote transports. This tool
+    // hands the caller a free-form kubectl argv, so the per-parameter guards
+    // the structured tools use have nothing to attach to: "--from-file",
+    // "-f" and friends arrive as raw tokens. See GHSA-m67f-jxm9-cvx8 for the
+    // read primitive and src/security/kubectl-flags.ts for the flag list.
+    // No-op under stdio, where the files are the operator's own.
+    assertNoRemoteFileReads(cmdArgs);
 
     // Execute the command
     try {

--- a/src/tools/kubectl-get.ts
+++ b/src/tools/kubectl-get.ts
@@ -1,5 +1,8 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSyncSafe } from "../security/kubectl-flags.js";
+import {
+  assertNotFlagLike,
+  execFileSyncSafe,
+} from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import * as yaml from "js-yaml";
@@ -75,6 +78,12 @@ export async function kubectlGet(
   }
 ) {
   try {
+    // A resource type or name is an RFC 1123 name, never a flag. Refusing a
+    // leading "-" closes the positional injection slot itself rather than
+    // relying on the argv denylist to know every dangerous flag.
+    assertNotFlagLike(input.resourceType, "resourceType");
+    assertNotFlagLike(input.name, "name");
+
     const resourceType = input.resourceType.toLowerCase();
     const name = input.name || "";
     const namespace = input.namespace || "default";

--- a/src/tools/kubectl-scale.ts
+++ b/src/tools/kubectl-scale.ts
@@ -1,5 +1,8 @@
 import { KubernetesManager } from "../types.js";
-import { execFileSyncSafe } from "../security/kubectl-flags.js";
+import {
+  assertNotFlagLike,
+  execFileSyncSafe,
+} from "../security/kubectl-flags.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getSpawnMaxBuffer } from "../config/max-buffer.js";
 import { contextParameter, namespaceParameter } from "../models/common-parameters.js";
@@ -45,6 +48,12 @@ export async function kubectlScale(
   }
 ) {
   try {
+    // A resource type or name is an RFC 1123 name, never a flag. Refusing a
+    // leading "-" closes the positional injection slot itself rather than
+    // relying on the argv denylist to know every dangerous flag.
+    assertNotFlagLike(input.resourceType, "resourceType");
+    assertNotFlagLike(input.name, "name");
+
     const namespace = input.namespace || "default";
     const resourceType = input.resourceType || "deployment";
     const context = input.context || "";

--- a/tests/kubectl-generic-file-read.unit.test.ts
+++ b/tests/kubectl-generic-file-read.unit.test.ts
@@ -4,11 +4,11 @@ import { kubectlGeneric } from "../src/tools/kubectl-generic.js";
 
 // kubectl_generic hands the caller a free-form kubectl argv, so the
 // per-parameter path guards the structured tools use (`filename`, `fromFile`,
-// `patchFile`, `valuesFile`) have nothing to attach to here: the same
-// server-side read arrives as a raw "--from-file=leak=/etc/passwd" token and
-// kubectl reflects the file back under --dry-run=client, without a cluster.
-// On remote transports that is an arbitrary file read on the server host; on
-// stdio the files are the operator's own and the flags stay allowed.
+// `patchFile`, `valuesFile`) have nothing to attach to here: a server-side
+// path arrives as a raw "--from-file=<key>=<path>" token instead. On remote
+// transports those paths resolve on the MCP server host rather than the
+// caller's machine and are rejected; on stdio the files are the operator's own
+// and the flags stay allowed.
 
 const TRANSPORT_ENV = [
   "ENABLE_UNSAFE_SSE_TRANSPORT",
@@ -70,10 +70,6 @@ describe("assertNoRemoteFileReads", () => {
       ["short attached", ["-f/etc/passwd"]],
       ["short clustered", ["-Rf/etc/passwd"]],
       ["short -k", ["-k/etc"]],
-      ["-o go-template-file split", ["-o", "go-template-file=/etc/passwd"]],
-      ["-o go-template-file attached", ["-ogo-template-file=/etc/passwd"]],
-      ["-o=jsonpath-file", ["-o=jsonpath-file=/etc/passwd"]],
-      ["--output=go-template-file", ["--output=go-template-file=/etc/passwd"]],
     ];
 
     for (const [label, argv] of rejected) {
@@ -141,16 +137,6 @@ describe("kubectl_generic rejects server-side file reads on remote transports", 
           resourceType: "configmap",
           name: "leak",
           flags: { "from-file": "leak=/etc/passwd", "dry-run": "client" },
-        })
-      ).rejects.toThrow(/reads a file from the MCP server's own filesystem/);
-    });
-
-    test(`rejects a file flag smuggled through a positional slot under ${envVar}`, async () => {
-      process.env[envVar] = "true";
-      await expect(
-        kubectlGeneric(manager, {
-          command: "create",
-          resourceType: "--from-file=leak=/etc/passwd",
         })
       ).rejects.toThrow(/reads a file from the MCP server's own filesystem/);
     });

--- a/tests/kubectl-generic-file-read.unit.test.ts
+++ b/tests/kubectl-generic-file-read.unit.test.ts
@@ -1,0 +1,158 @@
+import { expect, test, describe, beforeEach, afterEach } from "vitest";
+import { assertNoRemoteFileReads } from "../src/security/kubectl-flags.js";
+import { kubectlGeneric } from "../src/tools/kubectl-generic.js";
+
+// kubectl_generic hands the caller a free-form kubectl argv, so the
+// per-parameter path guards the structured tools use (`filename`, `fromFile`,
+// `patchFile`, `valuesFile`) have nothing to attach to here: the same
+// server-side read arrives as a raw "--from-file=leak=/etc/passwd" token and
+// kubectl reflects the file back under --dry-run=client, without a cluster.
+// On remote transports that is an arbitrary file read on the server host; on
+// stdio the files are the operator's own and the flags stay allowed.
+
+const TRANSPORT_ENV = [
+  "ENABLE_UNSAFE_SSE_TRANSPORT",
+  "ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT",
+] as const;
+
+// The guard runs before any kubectl execution, so a stub manager is fine.
+const manager = {} as any;
+
+describe("assertNoRemoteFileReads", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    TRANSPORT_ENV.forEach((k) => {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    });
+  });
+
+  afterEach(() => {
+    TRANSPORT_ENV.forEach((k) => {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    });
+  });
+
+  describe("under stdio", () => {
+    test("allows file-reading flags: the paths are the operator's own", () => {
+      expect(() =>
+        assertNoRemoteFileReads(["apply", "-f", "/home/me/app.yaml"])
+      ).not.toThrow();
+      expect(() =>
+        assertNoRemoteFileReads([
+          "create",
+          "configmap",
+          "cfg",
+          "--from-file=/home/me/app.conf",
+        ])
+      ).not.toThrow();
+    });
+  });
+
+  describe("under a remote transport", () => {
+    beforeEach(() => {
+      process.env.ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT = "true";
+    });
+
+    // Every spelling pflag accepts for the file-reading flags.
+    const rejected: [string, string[]][] = [
+      ["long joined", ["--from-file=leak=/etc/passwd"]],
+      ["long split", ["--from-file", "leak=/etc/passwd"]],
+      ["long underscore alias", ["--from_file=leak=/etc/passwd"]],
+      ["--filename", ["--filename=/etc/passwd"]],
+      ["--from-env-file", ["--from-env-file=/proc/self/environ"]],
+      ["--kustomize", ["--kustomize=/etc"]],
+      ["--patch-file", ["--patch-file=/etc/passwd"]],
+      ["short split", ["-f", "/etc/passwd"]],
+      ["short attached", ["-f/etc/passwd"]],
+      ["short clustered", ["-Rf/etc/passwd"]],
+      ["short -k", ["-k/etc"]],
+      ["-o go-template-file split", ["-o", "go-template-file=/etc/passwd"]],
+      ["-o go-template-file attached", ["-ogo-template-file=/etc/passwd"]],
+      ["-o=jsonpath-file", ["-o=jsonpath-file=/etc/passwd"]],
+      ["--output=go-template-file", ["--output=go-template-file=/etc/passwd"]],
+    ];
+
+    for (const [label, argv] of rejected) {
+      test(`rejects ${label}`, () => {
+        expect(() => assertNoRemoteFileReads(["create", ...argv])).toThrow(
+          /reads a file from the MCP server's own filesystem/
+        );
+      });
+    }
+
+    test("leaves benign argv alone", () => {
+      expect(() =>
+        assertNoRemoteFileReads([
+          "get",
+          "pods",
+          "--namespace=default",
+          "-o=json",
+          "-l",
+          "app=frontend",
+          "--context",
+          "prod",
+        ])
+      ).not.toThrow();
+    });
+  });
+});
+
+describe("kubectl_generic rejects server-side file reads on remote transports", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    TRANSPORT_ENV.forEach((k) => {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    });
+  });
+
+  afterEach(() => {
+    TRANSPORT_ENV.forEach((k) => {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    });
+  });
+
+  for (const envVar of TRANSPORT_ENV) {
+    test(`rejects --from-file passed through args under ${envVar}`, async () => {
+      process.env[envVar] = "true";
+      await expect(
+        kubectlGeneric(manager, {
+          command: "create",
+          resourceType: "configmap",
+          name: "leak",
+          args: ["--from-file=leak=/proc/self/environ", "--dry-run=client"],
+          outputFormat: "yaml",
+        })
+      ).rejects.toThrow(/reads a file from the MCP server's own filesystem/);
+    });
+
+    test(`rejects --from-file passed through the flags object under ${envVar}`, async () => {
+      process.env[envVar] = "true";
+      await expect(
+        kubectlGeneric(manager, {
+          command: "create",
+          resourceType: "configmap",
+          name: "leak",
+          flags: { "from-file": "leak=/etc/passwd", "dry-run": "client" },
+        })
+      ).rejects.toThrow(/reads a file from the MCP server's own filesystem/);
+    });
+
+    test(`rejects a file flag smuggled through a positional slot under ${envVar}`, async () => {
+      process.env[envVar] = "true";
+      await expect(
+        kubectlGeneric(manager, {
+          command: "create",
+          resourceType: "--from-file=leak=/etc/passwd",
+        })
+      ).rejects.toThrow(/reads a file from the MCP server's own filesystem/);
+    });
+  }
+});

--- a/tests/positional-flag-injection.unit.test.ts
+++ b/tests/positional-flag-injection.unit.test.ts
@@ -1,0 +1,147 @@
+import { expect, test, describe, beforeEach, afterEach } from "vitest";
+import { assertSafeArgv } from "../src/security/kubectl-flags.js";
+import { kubectlGet } from "../src/tools/kubectl-get.js";
+import { kubectlDescribe } from "../src/tools/kubectl-describe.js";
+import { kubectlDelete } from "../src/tools/kubectl-delete.js";
+import { kubectlScale } from "../src/tools/kubectl-scale.js";
+import { kubectlGeneric } from "../src/tools/kubectl-generic.js";
+
+// kubectl's pflag parser treats any "-"-prefixed token as a flag wherever it
+// sits, so a resource type or name pushed into a bare positional slot is a flag
+// injection point. assertSafeArgv is a denylist and can only refuse the flags
+// it knows about, so narrowing it flag-by-flag will always lag.
+//
+// Two layers close that: the operand slots refuse a leading "-" outright
+// (a resource type or name is never legitimately flag-shaped), and the
+// file-reading output formats are refused anywhere in the argv, on every
+// transport, since no tool ever emits one.
+
+// The guards run before any kubectl execution, so a stub manager is fine.
+const manager = {} as any;
+
+const INJECTED = "-o=go-template-file=/root/.kube/config";
+
+describe("assertSafeArgv rejects file-reading output formats", () => {
+  // These are refused on every transport: no tool ever legitimately emits one,
+  // and they are reachable through positional slots that exist in read-only
+  // tools too.
+  const rejected: [string, string[]][] = [
+    ["-o= form", ["-o=go-template-file=/etc/passwd"]],
+    ["-o attached", ["-ogo-template-file=/etc/passwd"]],
+    ["-o split", ["-o", "go-template-file=/etc/passwd"]],
+    ["clustered", ["-Aogo-template-file=/etc/passwd"]],
+    ["--output=", ["--output=go-template-file=/etc/passwd"]],
+    ["--output split", ["--output", "jsonpath-file=/etc/passwd"]],
+    ["custom-columns-file", ["-o=custom-columns-file=/etc/passwd"]],
+  ];
+
+  for (const [label, argv] of rejected) {
+    test(`rejects ${label}`, () => {
+      expect(() => assertSafeArgv(["get", "configmaps", ...argv])).toThrow(
+        /this output format takes a file path/
+      );
+    });
+  }
+
+  test("leaves the inline (non-file) formats alone", () => {
+    expect(() =>
+      assertSafeArgv(["get", "pods", "-o", "go-template={{.metadata.name}}"])
+    ).not.toThrow();
+    expect(() =>
+      assertSafeArgv(["get", "pods", "-o=jsonpath={.items[0].metadata.name}"])
+    ).not.toThrow();
+    expect(() =>
+      assertSafeArgv(["get", "pods", "-o=custom-columns=NAME:.metadata.name"])
+    ).not.toThrow();
+    expect(() => assertSafeArgv(["get", "pods", "-o", "json"])).not.toThrow();
+  });
+});
+
+describe("tools refuse flag-shaped positional operands", () => {
+  // The read primitive needs no cluster and no remote transport, so these are
+  // asserted under plain stdio.
+  const TRANSPORT_ENV = [
+    "ENABLE_UNSAFE_SSE_TRANSPORT",
+    "ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT",
+  ] as const;
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    TRANSPORT_ENV.forEach((k) => {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    });
+  });
+
+  afterEach(() => {
+    TRANSPORT_ENV.forEach((k) => {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    });
+  });
+
+  const flagLike = /does not begin with "-"/;
+
+  test("kubectl_get rejects a flag-shaped name", async () => {
+    // An `output` outside the documented set emits no trailing -o of its own,
+    // which is what makes the operand slot worth guarding directly.
+    await expect(
+      kubectlGet(manager, {
+        resourceType: "configmaps",
+        name: INJECTED,
+        output: "raw",
+      })
+    ).rejects.toThrow(flagLike);
+  });
+
+  test("kubectl_get rejects a flag-shaped resourceType", async () => {
+    await expect(
+      kubectlGet(manager, { resourceType: INJECTED, output: "raw" })
+    ).rejects.toThrow(flagLike);
+  });
+
+  test("kubectl_describe rejects a flag-shaped name", async () => {
+    await expect(
+      kubectlDescribe(manager, { resourceType: "configmaps", name: INJECTED })
+    ).rejects.toThrow(flagLike);
+  });
+
+  test("kubectl_delete rejects a flag-shaped name", async () => {
+    await expect(
+      kubectlDelete(manager, { resourceType: "configmaps", name: INJECTED })
+    ).rejects.toThrow(flagLike);
+  });
+
+  test("kubectl_scale rejects a flag-shaped name", async () => {
+    // kubectl_scale reports errors in its result payload rather than throwing.
+    const result: any = await kubectlScale(manager, {
+      name: INJECTED,
+      replicas: 1,
+    });
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.success).toBe(false);
+    expect(payload.message).toMatch(flagLike);
+  });
+
+  test("kubectl_generic rejects a flag-shaped resourceType", async () => {
+    await expect(
+      kubectlGeneric(manager, { command: "get", resourceType: INJECTED })
+    ).rejects.toThrow(flagLike);
+  });
+
+  test("kubectl_generic rejects a flag-shaped command", async () => {
+    await expect(
+      kubectlGeneric(manager, { command: INJECTED })
+    ).rejects.toThrow(flagLike);
+  });
+
+  test("kubectl_generic still allows flags in the args array", () => {
+    // `args` is the free-form slot; narrowing the operand slots must not
+    // narrow it. This one only has to survive the guards, so assert on the
+    // argv checker rather than executing kubectl.
+    expect(() =>
+      assertSafeArgv(["get", "pods", "--show-labels", "-o", "wide"])
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Two robustness gaps in how caller input reaches the kubectl argv, both in the
same family as #332 / #346 / #355 (transport-scoped path reads) and #366
(flag-shaped operands). Neither tool had been covered by those sweeps.

## `kubectl_generic` was missing the remote-transport file-read guard

Every file-taking tool rejects server-side paths on SSE/Streamable HTTP, where
a path chosen by the caller resolves on the MCP server host rather than the
caller's own machine. `kubectl_generic` builds its argv from caller-supplied
`flags`/`args`, so it has no path parameter for a per-parameter guard to attach
to and was never touched by those PRs.

Adds `assertNoRemoteFileReads(argv)`, rejecting `--filename`/`-f`,
`--from-file`, `--from-env-file`, `--kustomize`/`-k` and `--patch-file` on
remote transports only. Under stdio the paths are the operator's own and
everything stays allowed, matching the sibling guards.

It scans the fully-constructed argv rather than the `flags`/`args` inputs, so
the object form and the positional slots are covered in one pass, and it reuses
the existing pflag parsing so the attached (`-f/path`) and clustered
(`-Rf/path`) spellings are handled. No `ALLOW_KUBECTL_UNSAFE_FLAGS` escape
hatch, matching the unconditional transport guards elsewhere.

## Flag-shaped operands and file-reading output formats

`assertSafeArgv` is a denylist over the final argv, so a caller value landing in
a bare positional slot is only as safe as that list is complete. #366 closed
this for the helm operands with `assertNotFlagLike`; the kubectl tools still
pushed `resourceType` and `name` unguarded.

- Applies `assertNotFlagLike` to the `resourceType`/`name` operands of
  `kubectl_get`, `kubectl_describe`, `kubectl_delete` and `kubectl_scale`, and
  to `command`/`subCommand`/`resourceType`/`name` in `kubectl_generic`. These
  are RFC 1123 names, never flags, so refusing a leading `-` closes the slot
  itself instead of extending the denylist flag by flag. `kubectl_generic`'s
  free-form `args` array is untouched — that is where flags legitimately belong.

- Rejects the output formats whose argument is a file path
  (`go-template-file`, `jsonpath-file`, `custom-columns-file`) anywhere in the
  argv. These read a file on the machine kubectl runs on and render it into the
  result, and no tool here emits one, so unlike `--from-file` they are refused
  on every transport rather than only remote ones. Matched on the flag's value
  in every spelling pflag accepts (`-o=`, `-ofmt`, `-o fmt`, `--output=`,
  clustered). The inline `go-template` / `jsonpath` / `custom-columns` forms are
  unaffected.

`assertNotFlagLike`'s message no longer says "helm" now that the kubectl tools
use it; the helm tests match on the field name, not the tool.

## Tests

`tests/kubectl-generic-file-read.unit.test.ts` and
`tests/positional-flag-injection.unit.test.ts` — 33 new cases covering every
pflag spelling of the guarded flags, the operand slots of all five tools, and
negative cases confirming the inline output formats, the `args` array and
ordinary `kubectl get` are unaffected. Full unit suite (141) and `tsc --noEmit`
pass; `kubectl_get`, `kubectl_describe` and `kubectl_generic` were also
exercised against a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128PberJYFm2m4DWXkFdpd7
