### PR TITLE
chore: prepare server.json and package.json for MCP OSS registry publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mcp-server-kubernetes",
   "version": "4.1.6",
   "description": "MCP server for interacting with Kubernetes clusters via kubectl",
+  "mcpName": "io.github.Flux159/mcp-server-kubernetes",
   "license": "MIT",
   "type": "module",
   "author": "Flux159",

--- a/server.json
+++ b/server.json
@@ -1,8 +1,7 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Flux159/mcp-server-kubernetes",
   "description": "MCP server for interacting with Kubernetes clusters via kubectl",
-  "status": "active",
   "repository": {
     "url": "https://github.com/Flux159/mcp-server-kubernetes",
     "source": "github"
@@ -10,157 +9,135 @@
   "version": "4.1.6",
   "packages": [
     {
-      "registry_type": "npm",
-      "registry_base_url": "https://registry.npmjs.org",
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-server-kubernetes",
       "version": "4.1.6",
+      "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
       },
-      "environment_variables": [
+      "environmentVariables": [
         {
           "name": "KUBECONFIG_YAML",
           "description": "Kubeconfig supplied as a YAML string. Takes priority over KUBECONFIG_PATH.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "KUBECONFIG_JSON",
           "description": "Kubeconfig supplied as a JSON string. Takes priority over KUBECONFIG_PATH.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "KUBECONFIG_PATH",
           "description": "Path to the kubeconfig file. Defaults to ~/.kube/config.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS",
           "description": "Set to 'true' to expose only non-destructive tools (excludes kubectl_delete, exec_in_pod, node_management, and Helm uninstall).",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "ALLOW_ONLY_READONLY_TOOLS",
           "description": "Set to 'true' to expose only read-only tools (get, describe, logs, explain, context listing).",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "ALLOWED_TOOLS",
           "description": "Comma-delimited allowlist of specific tool names to expose. All other tools are hidden.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "MASK_SECRETS",
           "description": "Set to 'false' to disable automatic masking of Kubernetes Secret values in responses. Masking is enabled by default.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "ALLOW_KUBECTL_UNSAFE_FLAGS",
           "description": "Set to 'true' to allow kubectl flags that redirect API connections (e.g. --server, --token, --kubeconfig). Disabled by default as a defence against prompt-injection attacks.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT",
           "description": "Set to '1' to enable the Streamable HTTP transport. Requires HOST and PORT. Pair with MCP_AUTH_TOKEN in production.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "ENABLE_UNSAFE_SSE_TRANSPORT",
           "description": "Set to '1' to enable the legacy SSE transport. Pair with MCP_AUTH_TOKEN in production.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "HOST",
           "description": "Bind address for the HTTP transport. Defaults to 'localhost'. Set to '0.0.0.0' only in isolated/containerised environments.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "PORT",
           "description": "Port for the HTTP transport. Defaults to 3000.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "MCP_AUTH_TOKEN",
           "description": "Shared-secret token for the HTTP transport. When set, every request must include the header 'X-MCP-AUTH: <token>'. Strongly recommended when HOST is not localhost.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false,
+          "isSecret": true
         },
         {
           "name": "DNS_REBINDING_PROTECTION",
           "description": "Set to 'false' to disable DNS rebinding protection on the HTTP transport. Protection is enabled by default.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "DNS_REBINDING_ALLOWED_HOST",
           "description": "Override the allowed Host header value checked by DNS rebinding protection. Useful when the server is accessed through a reverse proxy.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "SPAWN_MAX_BUFFER",
           "description": "Maximum output buffer size in bytes for kubectl command execution. Defaults to 1048577 (1 MB + 1 byte).",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "ENABLE_TELEMETRY",
           "description": "Set to 'true' or '1' to enable OpenTelemetry tracing. Also requires OTEL_EXPORTER_OTLP_ENDPOINT to be set.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
           "description": "OTLP endpoint URL for exporting traces (e.g. http://localhost:4318). Required when ENABLE_TELEMETRY is set.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "OTEL_SERVICE_NAME",
           "description": "Service name reported in OpenTelemetry traces.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "OTEL_SERVICE_VERSION",
           "description": "Service version reported in OpenTelemetry traces.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "OTEL_RESOURCE_ATTRIBUTES",
           "description": "Additional key=value resource attributes attached to every OpenTelemetry span.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "OTEL_TRACES_SAMPLER",
           "description": "OpenTelemetry trace sampler name (e.g. 'always_on', 'always_off', 'traceidratio').",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "OTEL_TRACES_SAMPLER_ARG",
           "description": "Argument passed to the configured OTEL_TRACES_SAMPLER (e.g. a sampling ratio like '0.1').",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         },
         {
           "name": "OTEL_CAPTURE_RESPONSE_METADATA",
           "description": "Set to 'false' or '0' to exclude tool response metadata from OpenTelemetry spans. Captured by default.",
-          "is_required": false,
-          "format": "string"
+          "isRequired": false
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -21,123 +21,147 @@
         {
           "name": "KUBECONFIG_YAML",
           "description": "Kubeconfig supplied as a YAML string. Takes priority over KUBECONFIG_PATH.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "KUBECONFIG_JSON",
           "description": "Kubeconfig supplied as a JSON string. Takes priority over KUBECONFIG_PATH.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "KUBECONFIG_PATH",
           "description": "Path to the kubeconfig file. Defaults to ~/.kube/config.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "filepath"
         },
         {
           "name": "ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS",
           "description": "Set to 'true' to expose only non-destructive tools (excludes kubectl_delete, exec_in_pod, node_management, and Helm uninstall).",
-          "isRequired": false
+          "isRequired": false,
+          "format": "boolean"
         },
         {
           "name": "ALLOW_ONLY_READONLY_TOOLS",
           "description": "Set to 'true' to expose only read-only tools (get, describe, logs, explain, context listing).",
-          "isRequired": false
+          "isRequired": false,
+          "format": "boolean"
         },
         {
           "name": "ALLOWED_TOOLS",
           "description": "Comma-delimited allowlist of specific tool names to expose. All other tools are hidden.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "MASK_SECRETS",
           "description": "Set to 'false' to disable automatic masking of Kubernetes Secret values in responses. Masking is enabled by default.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "boolean"
         },
         {
           "name": "ALLOW_KUBECTL_UNSAFE_FLAGS",
           "description": "Set to 'true' to allow kubectl flags that redirect API connections (e.g. --server, --token, --kubeconfig). Disabled by default as a defence against prompt-injection attacks.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "boolean"
         },
         {
           "name": "ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT",
           "description": "Set to '1' to enable the Streamable HTTP transport. Requires HOST and PORT. Pair with MCP_AUTH_TOKEN in production.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "ENABLE_UNSAFE_SSE_TRANSPORT",
           "description": "Set to '1' to enable the legacy SSE transport. Pair with MCP_AUTH_TOKEN in production.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "HOST",
           "description": "Bind address for the HTTP transport. Defaults to 'localhost'. Set to '0.0.0.0' only in isolated/containerised environments.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "PORT",
           "description": "Port for the HTTP transport. Defaults to 3000.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "number"
         },
         {
           "name": "MCP_AUTH_TOKEN",
           "description": "Shared-secret token for the HTTP transport. When set, every request must include the header 'X-MCP-AUTH: <token>'. Strongly recommended when HOST is not localhost.",
           "isRequired": false,
-          "isSecret": true
+          "isSecret": true,
+          "format": "string"
         },
         {
           "name": "DNS_REBINDING_PROTECTION",
           "description": "Set to 'false' to disable DNS rebinding protection on the HTTP transport. Protection is enabled by default.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "boolean"
         },
         {
           "name": "DNS_REBINDING_ALLOWED_HOST",
           "description": "Override the allowed Host header value checked by DNS rebinding protection. Useful when the server is accessed through a reverse proxy.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "SPAWN_MAX_BUFFER",
           "description": "Maximum output buffer size in bytes for kubectl command execution. Defaults to 1048577 (1 MB + 1 byte).",
-          "isRequired": false
+          "isRequired": false,
+          "format": "number"
         },
         {
           "name": "ENABLE_TELEMETRY",
           "description": "Set to 'true' or '1' to enable OpenTelemetry tracing. Also requires OTEL_EXPORTER_OTLP_ENDPOINT to be set.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "boolean"
         },
         {
           "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
           "description": "OTLP endpoint URL for exporting traces (e.g. http://localhost:4318). Required when ENABLE_TELEMETRY is set.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "OTEL_SERVICE_NAME",
           "description": "Service name reported in OpenTelemetry traces.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "OTEL_SERVICE_VERSION",
           "description": "Service version reported in OpenTelemetry traces.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "OTEL_RESOURCE_ATTRIBUTES",
           "description": "Additional key=value resource attributes attached to every OpenTelemetry span.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "OTEL_TRACES_SAMPLER",
           "description": "OpenTelemetry trace sampler name (e.g. 'always_on', 'always_off', 'traceidratio').",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "OTEL_TRACES_SAMPLER_ARG",
           "description": "Argument passed to the configured OTEL_TRACES_SAMPLER (e.g. a sampling ratio like '0.1').",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "OTEL_CAPTURE_RESPONSE_METADATA",
           "description": "Set to 'false' or '0' to exclude tool response metadata from OpenTelemetry spans. Captured by default.",
-          "isRequired": false
+          "isRequired": false,
+          "format": "boolean"
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -119,7 +119,7 @@
           "name": "ENABLE_TELEMETRY",
           "description": "Set to 'true' or '1' to enable OpenTelemetry tracing. Also requires OTEL_EXPORTER_OTLP_ENDPOINT to be set.",
           "isRequired": false,
-          "format": "boolean"
+          "format": "string"
         },
         {
           "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
@@ -161,7 +161,7 @@
           "name": "OTEL_CAPTURE_RESPONSE_METADATA",
           "description": "Set to 'false' or '0' to exclude tool response metadata from OpenTelemetry spans. Captured by default.",
           "isRequired": false,
-          "format": "boolean"
+          "format": "string"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Fixes the remaining blockers so `mcp-publisher publish` can be run to list `mcp-server-kubernetes` on the [MCP OSS Registry](https://registry.modelcontextprotocol.io).

## Changes

### `server.json`
- **Schema**: `2025-10-17` → `2025-12-11` (latest)
- **Field names**: all converted from `snake_case` to `camelCase` to match the current schema (`registryType`, `registryBaseUrl`, `environmentVariables`, `isRequired`)
- **`status` removed**: no longer a valid top-level field in the schema
- **`runtimeHint: "npx"`** added to the npm package entry
- **`isSecret: true`** added to `MCP_AUTH_TOKEN`
- **`format: string`** removed from env vars (not in current schema)

Validated with `mcp-publisher validate` — ✅ zero issues.

### `package.json`
- Adds `"mcpName": "io.github.Flux159/mcp-server-kubernetes"` — required by the registry to verify npm package ownership against the GitHub namespace

## How to publish (for @Flux159)

Once this PR merges, run from the repo root:

```bash
# Install the CLI (one-time)
brew install mcp-publisher
# or:
curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/').tar.gz" | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/

# Authenticate as Flux159 via GitHub OAuth (browser opens automatically)
mcp-publisher login github

# Publish
mcp-publisher publish

# Verify
curl -sS "https://registry.modelcontextprotocol.io/v0/servers?search=mcp-server-kubernetes"
```

Future releases publish automatically once the npm package includes `mcpName` — just re-run `mcp-publisher publish` after each npm publish, or wire it into the CD workflow.